### PR TITLE
Test rpfba

### DIFF
--- a/rpFBA/wrap.xml
+++ b/rpFBA/wrap.xml
@@ -92,6 +92,42 @@
                 </assert_contents>
             </output>
         </test>
+        <test>
+        <!-- test 2: check if identical outputs are produced with R_BIOMASS__3 biomass name ID and BiGG model (iCN718)  and sim_type=fba-->
+            <param name="pathway" value="rp_001_0001.xml" />
+            <param name="model" value="iCN718.xml.gz" />
+            <param name="biomass_rxn_id" value="R_BIOMASS__3" />
+            <conditional name="input_sim_type">
+                <param name="sim_type" value="fba"/>
+            </conditional>
+            <output name="pathway_with_fba" >
+                <assert_contents>
+                    <is_valid_xml />
+                    <!--check fba_fba value-->
+                    <has_text text="16.47058" />
+                    <not_has_text text="fba_fraction" />
+                    <has_n_lines n="392" />
+                </assert_contents>
+            </output>
+        </test>
+        <test>
+        <!-- test 3: check if identical outputs are produced with R_DM_biomass_c biomass name ID and BiGG model (iCN718)  and sim_type=pfba-->
+            <param name="pathway" value="rp_001_0001.xml" />
+            <param name="model" value="iCN718.xml.gz" />
+            <param name="biomass_rxn_id" value="R_DM_biomass_c" />
+            <conditional name="input_sim_type">
+                <param name="sim_type" value="pfba"/>
+            </conditional>
+            <output name="pathway_with_fba" >
+                <assert_contents>
+                    <is_valid_xml />
+                    <!--check fba_pfba value-->
+                    <has_text text="2623.54248" />
+                    <not_has_text text="fba_fraction" />
+                    <has_n_lines n="392" />
+                </assert_contents>
+            </output>
+        </test>
     </tests>
     <help><![CDATA[
 FBA

--- a/rpFBA/wrap.xml
+++ b/rpFBA/wrap.xml
@@ -35,8 +35,8 @@
             #end if
     ]]></command>
     <inputs>
-        <param name="pathway" type="data" format="xml" label="Pathway (rpSBML)" />
-        <param name="model" type="data" format="xml" label="Model (SBML)" />
+        <param name="pathway" type="data" format="sbml" label="Pathway (rpSBML)" />
+        <param name="model" type="data" format="sbml" label="Model (SBML)" />
         <param name="compartment_id" type="text" label="SBML compartment ID" value="MNXC3" >
             <validator type="empty_field" message="A compartment ID is required"/>
         </param>
@@ -73,7 +73,7 @@
         </section>
     </inputs>
     <outputs>
-        <data name="pathway_with_fba" format="xml" label="${tool.name}(${input_sim_type.sim_type}) - ${pathway.name}" />
+        <data name="pathway_with_fba" format="sbml" label="${tool.name}(${input_sim_type.sim_type}) - ${pathway.name}" />
     </outputs>
     <tests>
         <test>


### PR DESCRIPTION
- Use sbml format instead of xml according to IUC recommendation:  https://github.com/galaxyproject/tools-iuc/pull/4324

```
Oh sorry this is a misunderstanding. Galaxy datatypes have nothing to do with the fileending. Galaxy datatypes are metadata that tells galaxy this tool can consume this datasets. SMBL is a specific XML datatype. So making a tool able to consume SMBL will filter the tool form to only see SMBL annotated file from the user history. E.g. blastxml files will be not shown.

The user is responsible to say during upload: This is a SMBL conform XML file.

Does that make sense?
```
- Add more tests to test conditionnal options sim_type=fba and sim_type=pfba