### PR TITLE
IUC rp2paths

### DIFF
--- a/rp2paths/wrap.xml
+++ b/rp2paths/wrap.xml
@@ -17,8 +17,8 @@
         '$rp2_pathways'
         --outdir out
         --timeout '$adv.timeout' &&
-        if test -f 'out/compounds.txt'; then
-            cp out/compounds.txt '$compounds';
+        cp out/compounds.txt '$compounds' &&
+        if test -f 'out/out_paths.csv'; then
             cp out/out_paths.csv '$master_pathways';
         fi
     ]]></command>

--- a/rp2paths/wrap.xml
+++ b/rp2paths/wrap.xml
@@ -79,20 +79,6 @@ Project Links
 
 * `GitHub <https://github.com/brsynth/rp2paths>`_
 
-Versioning
-----------
-
-1.5.0
-
-Authors
--------
-
-
-* **Melchior du Lac**
-* Thomas Duigou
-* Baudoin Delépine
-* Pablo Carbonell
-
 License
 -------
 


### PR DESCRIPTION
- test presence of `out_paths.csv` file because it's not always produced before copying it. Note that `compounds.txt `is always produced.
- delete tool version at help section because it's already captured at tool level.
- delete authors name at help section because they are already mentioned at the article level (citation)