### PR TITLE
Iuc rp2paths

### DIFF
--- a/rp2paths/wrap.xml
+++ b/rp2paths/wrap.xml
@@ -30,14 +30,14 @@
     </inputs>
     <outputs>
         <data name="master_pathways" format="csv" label="${tool.name} on ${rp2_pathways.name} : Enumerated Pathways" />
-        <data name="compounds" format="tsv" label="${tool.name} on ${rp2_pathways.name} : Compounds" />
+        <data name="compounds" format="tabular" label="${tool.name} on ${rp2_pathways.name} : Compounds" />
     </outputs>
     <tests>
         <test>
             <!-- test 1: check if identical outputs are produced with default parameters  -->
             <param name="rp2_pathways" value="retropath2_pathways.csv" />
             <output name="master_pathways" file="rp2paths_pathways.csv" ftype="csv" compare="diff"/>
-            <output name="compounds" file="rp2paths_compounds.tsv" ftype="tsv" compare="diff"/>
+            <output name="compounds" file="rp2paths_compounds.tsv" ftype="tabular" compare="diff"/>
         </test>
     </tests>
     <help><![CDATA[

--- a/rpCompletion/wrap.xml
+++ b/rpCompletion/wrap.xml
@@ -23,7 +23,7 @@
     ]]></command>
     <inputs>
         <param name="rp2paths_pathways" type="data" format="csv" label="RP2paths pathways" />
-        <param name="rp2paths_compounds" type="data" format="tsv" label="RP2paths compounds" />
+        <param name="rp2paths_compounds" type="data" format="tabular" label="RP2paths compounds" />
         <param name="rp2_pathways" type="data" format="csv" label="RetroPath2.0 metabolic network" />
         <param name="sink" type="data" format="csv" label="Sink from SBML" />
         <section name="adv" title="Advanced Options" expanded="false">


### PR DESCRIPTION
- Use tabular format instead of TSV output format for rp2paths tool
- Use tabular format instead of TSV input format for rpCompetion tool

IUC prefer to use TABULAR instead of TSV in this case : https://github.com/galaxyproject/tools-iuc/pull/4507

`This one should the format="tabular" ... Tsv and tabular are more or less the same, it's not good that we have both and we should use tabular as long as we fix those two and merge them`

They don't like to have CSV and (TSV or TABULAR) together. The objective is to use TABULAR instead of CSV format for next releases. But for now, TABULAR format will be used instead of TSV.