### PR TITLE
Test sbml2sbol (IUC requests)

### DIFF
--- a/sbml2sbol/test-data/sbol_lycopene_output2.xml
+++ b/sbml2sbol/test-data/sbol_lycopene_output2.xml
@@ -1,0 +1,1794 @@
+<?xml version="1.0" ?>
+<rdf:RDF xmlns:sys-bio="http://sys-bio.org#" xmlns:sbol="http://sbols.org/v2#" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:prov="http://www.w3.org/ns/prov#">
+  <sbol:ComponentDefinition rdf:about="http://liverpool.ac.uk/ComponentDefinition/P21688_30000_rbs/1">
+    <sbol:displayId>P21688_30000_rbs</sbol:displayId>
+    <sbol:persistentIdentity rdf:resource="http://liverpool.ac.uk/ComponentDefinition/P21688_30000_rbs"/>
+    <sbol:role rdf:resource="http://identifiers.org/so/SO:0000139"/>
+    <sbol:type rdf:resource="http://www.biopax.org/release/biopax-level3.owl#DnaRegion"/>
+    <sbol:version>1</sbol:version>
+  </sbol:ComponentDefinition>
+  <sbol:ComponentDefinition rdf:about="http://liverpool.ac.uk/ComponentDefinition/P21688_20000_gene/1">
+    <sbol:displayId>P21688_20000_gene</sbol:displayId>
+    <sbol:persistentIdentity rdf:resource="http://liverpool.ac.uk/ComponentDefinition/P21688_20000_gene"/>
+    <sbol:role rdf:resource="http://identifiers.org/so/SO:0000704"/>
+    <sbol:type rdf:resource="http://www.biopax.org/release/biopax-level3.owl#DnaRegion"/>
+    <sbol:type rdf:resource="http://identifiers.org/so/SO:0000987"/>
+    <sbol:version>1</sbol:version>
+    <sbol:component>
+      <sbol:Component rdf:about="http://liverpool.ac.uk/ComponentDefinition/P21688_20000_gene/rxn_3_5_prime_assembly_0/1">
+        <sbol:access rdf:resource="http://sbols.org/v2#public"/>
+        <sbol:definition rdf:resource="http://liverpool.ac.uk/ComponentDefinition/rxn_3_5_prime_assembly/1"/>
+        <sbol:displayId>rxn_3_5_prime_assembly_0</sbol:displayId>
+        <sbol:persistentIdentity rdf:resource="http://liverpool.ac.uk/ComponentDefinition/P21688_20000_gene/rxn_3_5_prime_assembly_0"/>
+        <sbol:roleIntegration rdf:resource="http://sbols.org/v2#mergeRoles"/>
+        <sbol:version>1</sbol:version>
+      </sbol:Component>
+    </sbol:component>
+    <sbol:component>
+      <sbol:Component rdf:about="http://liverpool.ac.uk/ComponentDefinition/P21688_20000_gene/P21688_20000_rbs_0/1">
+        <sbol:access rdf:resource="http://sbols.org/v2#public"/>
+        <sbol:definition rdf:resource="http://liverpool.ac.uk/ComponentDefinition/P21688_20000_rbs/1"/>
+        <sbol:displayId>P21688_20000_rbs_0</sbol:displayId>
+        <sbol:persistentIdentity rdf:resource="http://liverpool.ac.uk/ComponentDefinition/P21688_20000_gene/P21688_20000_rbs_0"/>
+        <sbol:roleIntegration rdf:resource="http://sbols.org/v2#mergeRoles"/>
+        <sbol:version>1</sbol:version>
+      </sbol:Component>
+    </sbol:component>
+    <sbol:component>
+      <sbol:Component rdf:about="http://liverpool.ac.uk/ComponentDefinition/P21688_20000_gene/P21688_20000_cds_0/1">
+        <sbol:access rdf:resource="http://sbols.org/v2#public"/>
+        <sbol:definition rdf:resource="http://liverpool.ac.uk/ComponentDefinition/P21688_20000_cds/1"/>
+        <sbol:displayId>P21688_20000_cds_0</sbol:displayId>
+        <sbol:persistentIdentity rdf:resource="http://liverpool.ac.uk/ComponentDefinition/P21688_20000_gene/P21688_20000_cds_0"/>
+        <sbol:roleIntegration rdf:resource="http://sbols.org/v2#mergeRoles"/>
+        <sbol:version>1</sbol:version>
+      </sbol:Component>
+    </sbol:component>
+    <sbol:component>
+      <sbol:Component rdf:about="http://liverpool.ac.uk/ComponentDefinition/P21688_20000_gene/rxn_3_3_prime_assembly_0/1">
+        <sbol:access rdf:resource="http://sbols.org/v2#public"/>
+        <sbol:definition rdf:resource="http://liverpool.ac.uk/ComponentDefinition/rxn_3_3_prime_assembly/1"/>
+        <sbol:displayId>rxn_3_3_prime_assembly_0</sbol:displayId>
+        <sbol:persistentIdentity rdf:resource="http://liverpool.ac.uk/ComponentDefinition/P21688_20000_gene/rxn_3_3_prime_assembly_0"/>
+        <sbol:roleIntegration rdf:resource="http://sbols.org/v2#mergeRoles"/>
+        <sbol:version>1</sbol:version>
+      </sbol:Component>
+    </sbol:component>
+    <sbol:sequenceConstraint>
+      <sbol:SequenceConstraint rdf:about="http://liverpool.ac.uk/ComponentDefinition/P21688_20000_gene/constraint_0/1">
+        <sbol:displayId>constraint_0</sbol:displayId>
+        <sbol:object rdf:resource="http://liverpool.ac.uk/ComponentDefinition/P21688_20000_gene/P21688_20000_rbs_0/1"/>
+        <sbol:persistentIdentity rdf:resource="http://liverpool.ac.uk/ComponentDefinition/P21688_20000_gene/constraint_0"/>
+        <sbol:restriction rdf:resource="http://sbols.org/v2#precedes"/>
+        <sbol:subject rdf:resource="http://liverpool.ac.uk/ComponentDefinition/P21688_20000_gene/rxn_3_5_prime_assembly_0/1"/>
+        <sbol:version>1</sbol:version>
+      </sbol:SequenceConstraint>
+    </sbol:sequenceConstraint>
+    <sbol:sequenceConstraint>
+      <sbol:SequenceConstraint rdf:about="http://liverpool.ac.uk/ComponentDefinition/P21688_20000_gene/constraint_1/1">
+        <sbol:displayId>constraint_1</sbol:displayId>
+        <sbol:object rdf:resource="http://liverpool.ac.uk/ComponentDefinition/P21688_20000_gene/P21688_20000_cds_0/1"/>
+        <sbol:persistentIdentity rdf:resource="http://liverpool.ac.uk/ComponentDefinition/P21688_20000_gene/constraint_1"/>
+        <sbol:restriction rdf:resource="http://sbols.org/v2#precedes"/>
+        <sbol:subject rdf:resource="http://liverpool.ac.uk/ComponentDefinition/P21688_20000_gene/P21688_20000_rbs_0/1"/>
+        <sbol:version>1</sbol:version>
+      </sbol:SequenceConstraint>
+    </sbol:sequenceConstraint>
+    <sbol:sequenceConstraint>
+      <sbol:SequenceConstraint rdf:about="http://liverpool.ac.uk/ComponentDefinition/P21688_20000_gene/constraint_2/1">
+        <sbol:displayId>constraint_2</sbol:displayId>
+        <sbol:object rdf:resource="http://liverpool.ac.uk/ComponentDefinition/P21688_20000_gene/rxn_3_3_prime_assembly_0/1"/>
+        <sbol:persistentIdentity rdf:resource="http://liverpool.ac.uk/ComponentDefinition/P21688_20000_gene/constraint_2"/>
+        <sbol:restriction rdf:resource="http://sbols.org/v2#precedes"/>
+        <sbol:subject rdf:resource="http://liverpool.ac.uk/ComponentDefinition/P21688_20000_gene/P21688_20000_cds_0/1"/>
+        <sbol:version>1</sbol:version>
+      </sbol:SequenceConstraint>
+    </sbol:sequenceConstraint>
+  </sbol:ComponentDefinition>
+  <sbol:ComponentDefinition rdf:about="http://liverpool.ac.uk/ComponentDefinition/P21688_20000_cds/1">
+    <sbol:displayId>P21688_20000_cds</sbol:displayId>
+    <sbol:persistentIdentity rdf:resource="http://liverpool.ac.uk/ComponentDefinition/P21688_20000_cds"/>
+    <sbol:role rdf:resource="http://identifiers.org/so/SO:0000316"/>
+    <sbol:type rdf:resource="http://www.biopax.org/release/biopax-level3.owl#DnaRegion"/>
+    <sbol:version>1</sbol:version>
+  </sbol:ComponentDefinition>
+  <sbol:ComponentDefinition rdf:about="http://liverpool.ac.uk/ComponentDefinition/P21688_30000_gene/1">
+    <sbol:displayId>P21688_30000_gene</sbol:displayId>
+    <sbol:persistentIdentity rdf:resource="http://liverpool.ac.uk/ComponentDefinition/P21688_30000_gene"/>
+    <sbol:role rdf:resource="http://identifiers.org/so/SO:0000704"/>
+    <sbol:type rdf:resource="http://www.biopax.org/release/biopax-level3.owl#DnaRegion"/>
+    <sbol:type rdf:resource="http://identifiers.org/so/SO:0000987"/>
+    <sbol:version>1</sbol:version>
+    <sbol:component>
+      <sbol:Component rdf:about="http://liverpool.ac.uk/ComponentDefinition/P21688_30000_gene/rxn_3_5_prime_assembly_0/1">
+        <sbol:access rdf:resource="http://sbols.org/v2#public"/>
+        <sbol:definition rdf:resource="http://liverpool.ac.uk/ComponentDefinition/rxn_3_5_prime_assembly/1"/>
+        <sbol:displayId>rxn_3_5_prime_assembly_0</sbol:displayId>
+        <sbol:persistentIdentity rdf:resource="http://liverpool.ac.uk/ComponentDefinition/P21688_30000_gene/rxn_3_5_prime_assembly_0"/>
+        <sbol:roleIntegration rdf:resource="http://sbols.org/v2#mergeRoles"/>
+        <sbol:version>1</sbol:version>
+      </sbol:Component>
+    </sbol:component>
+    <sbol:component>
+      <sbol:Component rdf:about="http://liverpool.ac.uk/ComponentDefinition/P21688_30000_gene/P21688_30000_rbs_0/1">
+        <sbol:access rdf:resource="http://sbols.org/v2#public"/>
+        <sbol:definition rdf:resource="http://liverpool.ac.uk/ComponentDefinition/P21688_30000_rbs/1"/>
+        <sbol:displayId>P21688_30000_rbs_0</sbol:displayId>
+        <sbol:persistentIdentity rdf:resource="http://liverpool.ac.uk/ComponentDefinition/P21688_30000_gene/P21688_30000_rbs_0"/>
+        <sbol:roleIntegration rdf:resource="http://sbols.org/v2#mergeRoles"/>
+        <sbol:version>1</sbol:version>
+      </sbol:Component>
+    </sbol:component>
+    <sbol:component>
+      <sbol:Component rdf:about="http://liverpool.ac.uk/ComponentDefinition/P21688_30000_gene/P21688_30000_cds_0/1">
+        <sbol:access rdf:resource="http://sbols.org/v2#public"/>
+        <sbol:definition rdf:resource="http://liverpool.ac.uk/ComponentDefinition/P21688_30000_cds/1"/>
+        <sbol:displayId>P21688_30000_cds_0</sbol:displayId>
+        <sbol:persistentIdentity rdf:resource="http://liverpool.ac.uk/ComponentDefinition/P21688_30000_gene/P21688_30000_cds_0"/>
+        <sbol:roleIntegration rdf:resource="http://sbols.org/v2#mergeRoles"/>
+        <sbol:version>1</sbol:version>
+      </sbol:Component>
+    </sbol:component>
+    <sbol:component>
+      <sbol:Component rdf:about="http://liverpool.ac.uk/ComponentDefinition/P21688_30000_gene/rxn_3_3_prime_assembly_0/1">
+        <sbol:access rdf:resource="http://sbols.org/v2#public"/>
+        <sbol:definition rdf:resource="http://liverpool.ac.uk/ComponentDefinition/rxn_3_3_prime_assembly/1"/>
+        <sbol:displayId>rxn_3_3_prime_assembly_0</sbol:displayId>
+        <sbol:persistentIdentity rdf:resource="http://liverpool.ac.uk/ComponentDefinition/P21688_30000_gene/rxn_3_3_prime_assembly_0"/>
+        <sbol:roleIntegration rdf:resource="http://sbols.org/v2#mergeRoles"/>
+        <sbol:version>1</sbol:version>
+      </sbol:Component>
+    </sbol:component>
+    <sbol:sequenceConstraint>
+      <sbol:SequenceConstraint rdf:about="http://liverpool.ac.uk/ComponentDefinition/P21688_30000_gene/constraint_0/1">
+        <sbol:displayId>constraint_0</sbol:displayId>
+        <sbol:object rdf:resource="http://liverpool.ac.uk/ComponentDefinition/P21688_30000_gene/P21688_30000_rbs_0/1"/>
+        <sbol:persistentIdentity rdf:resource="http://liverpool.ac.uk/ComponentDefinition/P21688_30000_gene/constraint_0"/>
+        <sbol:restriction rdf:resource="http://sbols.org/v2#precedes"/>
+        <sbol:subject rdf:resource="http://liverpool.ac.uk/ComponentDefinition/P21688_30000_gene/rxn_3_5_prime_assembly_0/1"/>
+        <sbol:version>1</sbol:version>
+      </sbol:SequenceConstraint>
+    </sbol:sequenceConstraint>
+    <sbol:sequenceConstraint>
+      <sbol:SequenceConstraint rdf:about="http://liverpool.ac.uk/ComponentDefinition/P21688_30000_gene/constraint_1/1">
+        <sbol:displayId>constraint_1</sbol:displayId>
+        <sbol:object rdf:resource="http://liverpool.ac.uk/ComponentDefinition/P21688_30000_gene/P21688_30000_cds_0/1"/>
+        <sbol:persistentIdentity rdf:resource="http://liverpool.ac.uk/ComponentDefinition/P21688_30000_gene/constraint_1"/>
+        <sbol:restriction rdf:resource="http://sbols.org/v2#precedes"/>
+        <sbol:subject rdf:resource="http://liverpool.ac.uk/ComponentDefinition/P21688_30000_gene/P21688_30000_rbs_0/1"/>
+        <sbol:version>1</sbol:version>
+      </sbol:SequenceConstraint>
+    </sbol:sequenceConstraint>
+    <sbol:sequenceConstraint>
+      <sbol:SequenceConstraint rdf:about="http://liverpool.ac.uk/ComponentDefinition/P21688_30000_gene/constraint_2/1">
+        <sbol:displayId>constraint_2</sbol:displayId>
+        <sbol:object rdf:resource="http://liverpool.ac.uk/ComponentDefinition/P21688_30000_gene/rxn_3_3_prime_assembly_0/1"/>
+        <sbol:persistentIdentity rdf:resource="http://liverpool.ac.uk/ComponentDefinition/P21688_30000_gene/constraint_2"/>
+        <sbol:restriction rdf:resource="http://sbols.org/v2#precedes"/>
+        <sbol:subject rdf:resource="http://liverpool.ac.uk/ComponentDefinition/P21688_30000_gene/P21688_30000_cds_0/1"/>
+        <sbol:version>1</sbol:version>
+      </sbol:SequenceConstraint>
+    </sbol:sequenceConstraint>
+  </sbol:ComponentDefinition>
+  <sbol:ComponentDefinition rdf:about="http://liverpool.ac.uk/ComponentDefinition/P21683_30000_gene/1">
+    <sbol:displayId>P21683_30000_gene</sbol:displayId>
+    <sbol:persistentIdentity rdf:resource="http://liverpool.ac.uk/ComponentDefinition/P21683_30000_gene"/>
+    <sbol:role rdf:resource="http://identifiers.org/so/SO:0000704"/>
+    <sbol:type rdf:resource="http://www.biopax.org/release/biopax-level3.owl#DnaRegion"/>
+    <sbol:type rdf:resource="http://identifiers.org/so/SO:0000987"/>
+    <sbol:type rdf:resource="http://identifiers.org/so/SO:0000987"/>
+    <sbol:type rdf:resource="http://identifiers.org/so/SO:0000987"/>
+    <sbol:version>1</sbol:version>
+    <sbol:component>
+      <sbol:Component rdf:about="http://liverpool.ac.uk/ComponentDefinition/P21683_30000_gene/rxn_1_5_prime_assembly_0/1">
+        <sbol:access rdf:resource="http://sbols.org/v2#public"/>
+        <sbol:definition rdf:resource="http://liverpool.ac.uk/ComponentDefinition/rxn_1_5_prime_assembly/1"/>
+        <sbol:displayId>rxn_1_5_prime_assembly_0</sbol:displayId>
+        <sbol:persistentIdentity rdf:resource="http://liverpool.ac.uk/ComponentDefinition/P21683_30000_gene/rxn_1_5_prime_assembly_0"/>
+        <sbol:roleIntegration rdf:resource="http://sbols.org/v2#mergeRoles"/>
+        <sbol:version>1</sbol:version>
+      </sbol:Component>
+    </sbol:component>
+    <sbol:component>
+      <sbol:Component rdf:about="http://liverpool.ac.uk/ComponentDefinition/P21683_30000_gene/P21683_30000_rbs_0/1">
+        <sbol:access rdf:resource="http://sbols.org/v2#public"/>
+        <sbol:definition rdf:resource="http://liverpool.ac.uk/ComponentDefinition/P21683_30000_rbs/1"/>
+        <sbol:displayId>P21683_30000_rbs_0</sbol:displayId>
+        <sbol:persistentIdentity rdf:resource="http://liverpool.ac.uk/ComponentDefinition/P21683_30000_gene/P21683_30000_rbs_0"/>
+        <sbol:roleIntegration rdf:resource="http://sbols.org/v2#mergeRoles"/>
+        <sbol:version>1</sbol:version>
+      </sbol:Component>
+    </sbol:component>
+    <sbol:component>
+      <sbol:Component rdf:about="http://liverpool.ac.uk/ComponentDefinition/P21683_30000_gene/P21683_30000_cds_0/1">
+        <sbol:access rdf:resource="http://sbols.org/v2#public"/>
+        <sbol:definition rdf:resource="http://liverpool.ac.uk/ComponentDefinition/P21683_30000_cds/1"/>
+        <sbol:displayId>P21683_30000_cds_0</sbol:displayId>
+        <sbol:persistentIdentity rdf:resource="http://liverpool.ac.uk/ComponentDefinition/P21683_30000_gene/P21683_30000_cds_0"/>
+        <sbol:roleIntegration rdf:resource="http://sbols.org/v2#mergeRoles"/>
+        <sbol:version>1</sbol:version>
+      </sbol:Component>
+    </sbol:component>
+    <sbol:component>
+      <sbol:Component rdf:about="http://liverpool.ac.uk/ComponentDefinition/P21683_30000_gene/rxn_1_3_prime_assembly_0/1">
+        <sbol:access rdf:resource="http://sbols.org/v2#public"/>
+        <sbol:definition rdf:resource="http://liverpool.ac.uk/ComponentDefinition/rxn_1_3_prime_assembly/1"/>
+        <sbol:displayId>rxn_1_3_prime_assembly_0</sbol:displayId>
+        <sbol:persistentIdentity rdf:resource="http://liverpool.ac.uk/ComponentDefinition/P21683_30000_gene/rxn_1_3_prime_assembly_0"/>
+        <sbol:roleIntegration rdf:resource="http://sbols.org/v2#mergeRoles"/>
+        <sbol:version>1</sbol:version>
+      </sbol:Component>
+    </sbol:component>
+    <sbol:component>
+      <sbol:Component rdf:about="http://liverpool.ac.uk/ComponentDefinition/P21683_30000_gene/rxn_2_5_prime_assembly_0/1">
+        <sbol:access rdf:resource="http://sbols.org/v2#public"/>
+        <sbol:definition rdf:resource="http://liverpool.ac.uk/ComponentDefinition/rxn_2_5_prime_assembly/1"/>
+        <sbol:displayId>rxn_2_5_prime_assembly_0</sbol:displayId>
+        <sbol:persistentIdentity rdf:resource="http://liverpool.ac.uk/ComponentDefinition/P21683_30000_gene/rxn_2_5_prime_assembly_0"/>
+        <sbol:roleIntegration rdf:resource="http://sbols.org/v2#mergeRoles"/>
+        <sbol:version>1</sbol:version>
+      </sbol:Component>
+    </sbol:component>
+    <sbol:component>
+      <sbol:Component rdf:about="http://liverpool.ac.uk/ComponentDefinition/P21683_30000_gene/P21683_30000_rbs_1/1">
+        <sbol:access rdf:resource="http://sbols.org/v2#public"/>
+        <sbol:definition rdf:resource="http://liverpool.ac.uk/ComponentDefinition/P21683_30000_rbs/1"/>
+        <sbol:displayId>P21683_30000_rbs_1</sbol:displayId>
+        <sbol:persistentIdentity rdf:resource="http://liverpool.ac.uk/ComponentDefinition/P21683_30000_gene/P21683_30000_rbs_1"/>
+        <sbol:roleIntegration rdf:resource="http://sbols.org/v2#mergeRoles"/>
+        <sbol:version>1</sbol:version>
+      </sbol:Component>
+    </sbol:component>
+    <sbol:component>
+      <sbol:Component rdf:about="http://liverpool.ac.uk/ComponentDefinition/P21683_30000_gene/P21683_30000_cds_1/1">
+        <sbol:access rdf:resource="http://sbols.org/v2#public"/>
+        <sbol:definition rdf:resource="http://liverpool.ac.uk/ComponentDefinition/P21683_30000_cds/1"/>
+        <sbol:displayId>P21683_30000_cds_1</sbol:displayId>
+        <sbol:persistentIdentity rdf:resource="http://liverpool.ac.uk/ComponentDefinition/P21683_30000_gene/P21683_30000_cds_1"/>
+        <sbol:roleIntegration rdf:resource="http://sbols.org/v2#mergeRoles"/>
+        <sbol:version>1</sbol:version>
+      </sbol:Component>
+    </sbol:component>
+    <sbol:component>
+      <sbol:Component rdf:about="http://liverpool.ac.uk/ComponentDefinition/P21683_30000_gene/rxn_2_3_prime_assembly_0/1">
+        <sbol:access rdf:resource="http://sbols.org/v2#public"/>
+        <sbol:definition rdf:resource="http://liverpool.ac.uk/ComponentDefinition/rxn_2_3_prime_assembly/1"/>
+        <sbol:displayId>rxn_2_3_prime_assembly_0</sbol:displayId>
+        <sbol:persistentIdentity rdf:resource="http://liverpool.ac.uk/ComponentDefinition/P21683_30000_gene/rxn_2_3_prime_assembly_0"/>
+        <sbol:roleIntegration rdf:resource="http://sbols.org/v2#mergeRoles"/>
+        <sbol:version>1</sbol:version>
+      </sbol:Component>
+    </sbol:component>
+    <sbol:component>
+      <sbol:Component rdf:about="http://liverpool.ac.uk/ComponentDefinition/P21683_30000_gene/rxn_3_5_prime_assembly_0/1">
+        <sbol:access rdf:resource="http://sbols.org/v2#public"/>
+        <sbol:definition rdf:resource="http://liverpool.ac.uk/ComponentDefinition/rxn_3_5_prime_assembly/1"/>
+        <sbol:displayId>rxn_3_5_prime_assembly_0</sbol:displayId>
+        <sbol:persistentIdentity rdf:resource="http://liverpool.ac.uk/ComponentDefinition/P21683_30000_gene/rxn_3_5_prime_assembly_0"/>
+        <sbol:roleIntegration rdf:resource="http://sbols.org/v2#mergeRoles"/>
+        <sbol:version>1</sbol:version>
+      </sbol:Component>
+    </sbol:component>
+    <sbol:component>
+      <sbol:Component rdf:about="http://liverpool.ac.uk/ComponentDefinition/P21683_30000_gene/P21683_30000_rbs_2/1">
+        <sbol:access rdf:resource="http://sbols.org/v2#public"/>
+        <sbol:definition rdf:resource="http://liverpool.ac.uk/ComponentDefinition/P21683_30000_rbs/1"/>
+        <sbol:displayId>P21683_30000_rbs_2</sbol:displayId>
+        <sbol:persistentIdentity rdf:resource="http://liverpool.ac.uk/ComponentDefinition/P21683_30000_gene/P21683_30000_rbs_2"/>
+        <sbol:roleIntegration rdf:resource="http://sbols.org/v2#mergeRoles"/>
+        <sbol:version>1</sbol:version>
+      </sbol:Component>
+    </sbol:component>
+    <sbol:component>
+      <sbol:Component rdf:about="http://liverpool.ac.uk/ComponentDefinition/P21683_30000_gene/P21683_30000_cds_2/1">
+        <sbol:access rdf:resource="http://sbols.org/v2#public"/>
+        <sbol:definition rdf:resource="http://liverpool.ac.uk/ComponentDefinition/P21683_30000_cds/1"/>
+        <sbol:displayId>P21683_30000_cds_2</sbol:displayId>
+        <sbol:persistentIdentity rdf:resource="http://liverpool.ac.uk/ComponentDefinition/P21683_30000_gene/P21683_30000_cds_2"/>
+        <sbol:roleIntegration rdf:resource="http://sbols.org/v2#mergeRoles"/>
+        <sbol:version>1</sbol:version>
+      </sbol:Component>
+    </sbol:component>
+    <sbol:component>
+      <sbol:Component rdf:about="http://liverpool.ac.uk/ComponentDefinition/P21683_30000_gene/rxn_3_3_prime_assembly_0/1">
+        <sbol:access rdf:resource="http://sbols.org/v2#public"/>
+        <sbol:definition rdf:resource="http://liverpool.ac.uk/ComponentDefinition/rxn_3_3_prime_assembly/1"/>
+        <sbol:displayId>rxn_3_3_prime_assembly_0</sbol:displayId>
+        <sbol:persistentIdentity rdf:resource="http://liverpool.ac.uk/ComponentDefinition/P21683_30000_gene/rxn_3_3_prime_assembly_0"/>
+        <sbol:roleIntegration rdf:resource="http://sbols.org/v2#mergeRoles"/>
+        <sbol:version>1</sbol:version>
+      </sbol:Component>
+    </sbol:component>
+    <sbol:sequenceConstraint>
+      <sbol:SequenceConstraint rdf:about="http://liverpool.ac.uk/ComponentDefinition/P21683_30000_gene/constraint_0/1">
+        <sbol:displayId>constraint_0</sbol:displayId>
+        <sbol:object rdf:resource="http://liverpool.ac.uk/ComponentDefinition/P21683_30000_gene/P21683_30000_rbs_2/1"/>
+        <sbol:persistentIdentity rdf:resource="http://liverpool.ac.uk/ComponentDefinition/P21683_30000_gene/constraint_0"/>
+        <sbol:restriction rdf:resource="http://sbols.org/v2#precedes"/>
+        <sbol:subject rdf:resource="http://liverpool.ac.uk/ComponentDefinition/P21683_30000_gene/rxn_3_5_prime_assembly_0/1"/>
+        <sbol:version>1</sbol:version>
+      </sbol:SequenceConstraint>
+    </sbol:sequenceConstraint>
+    <sbol:sequenceConstraint>
+      <sbol:SequenceConstraint rdf:about="http://liverpool.ac.uk/ComponentDefinition/P21683_30000_gene/constraint_1/1">
+        <sbol:displayId>constraint_1</sbol:displayId>
+        <sbol:object rdf:resource="http://liverpool.ac.uk/ComponentDefinition/P21683_30000_gene/P21683_30000_cds_2/1"/>
+        <sbol:persistentIdentity rdf:resource="http://liverpool.ac.uk/ComponentDefinition/P21683_30000_gene/constraint_1"/>
+        <sbol:restriction rdf:resource="http://sbols.org/v2#precedes"/>
+        <sbol:subject rdf:resource="http://liverpool.ac.uk/ComponentDefinition/P21683_30000_gene/P21683_30000_rbs_2/1"/>
+        <sbol:version>1</sbol:version>
+      </sbol:SequenceConstraint>
+    </sbol:sequenceConstraint>
+    <sbol:sequenceConstraint>
+      <sbol:SequenceConstraint rdf:about="http://liverpool.ac.uk/ComponentDefinition/P21683_30000_gene/constraint_2/1">
+        <sbol:displayId>constraint_2</sbol:displayId>
+        <sbol:object rdf:resource="http://liverpool.ac.uk/ComponentDefinition/P21683_30000_gene/rxn_3_3_prime_assembly_0/1"/>
+        <sbol:persistentIdentity rdf:resource="http://liverpool.ac.uk/ComponentDefinition/P21683_30000_gene/constraint_2"/>
+        <sbol:restriction rdf:resource="http://sbols.org/v2#precedes"/>
+        <sbol:subject rdf:resource="http://liverpool.ac.uk/ComponentDefinition/P21683_30000_gene/P21683_30000_cds_2/1"/>
+        <sbol:version>1</sbol:version>
+      </sbol:SequenceConstraint>
+    </sbol:sequenceConstraint>
+  </sbol:ComponentDefinition>
+  <sbol:ComponentDefinition rdf:about="http://liverpool.ac.uk/ComponentDefinition/P21683_20000_gene/1">
+    <sbol:displayId>P21683_20000_gene</sbol:displayId>
+    <sbol:persistentIdentity rdf:resource="http://liverpool.ac.uk/ComponentDefinition/P21683_20000_gene"/>
+    <sbol:role rdf:resource="http://identifiers.org/so/SO:0000704"/>
+    <sbol:type rdf:resource="http://www.biopax.org/release/biopax-level3.owl#DnaRegion"/>
+    <sbol:type rdf:resource="http://identifiers.org/so/SO:0000987"/>
+    <sbol:type rdf:resource="http://identifiers.org/so/SO:0000987"/>
+    <sbol:type rdf:resource="http://identifiers.org/so/SO:0000987"/>
+    <sbol:version>1</sbol:version>
+    <sbol:component>
+      <sbol:Component rdf:about="http://liverpool.ac.uk/ComponentDefinition/P21683_20000_gene/rxn_1_5_prime_assembly_0/1">
+        <sbol:access rdf:resource="http://sbols.org/v2#public"/>
+        <sbol:definition rdf:resource="http://liverpool.ac.uk/ComponentDefinition/rxn_1_5_prime_assembly/1"/>
+        <sbol:displayId>rxn_1_5_prime_assembly_0</sbol:displayId>
+        <sbol:persistentIdentity rdf:resource="http://liverpool.ac.uk/ComponentDefinition/P21683_20000_gene/rxn_1_5_prime_assembly_0"/>
+        <sbol:roleIntegration rdf:resource="http://sbols.org/v2#mergeRoles"/>
+        <sbol:version>1</sbol:version>
+      </sbol:Component>
+    </sbol:component>
+    <sbol:component>
+      <sbol:Component rdf:about="http://liverpool.ac.uk/ComponentDefinition/P21683_20000_gene/P21683_20000_rbs_0/1">
+        <sbol:access rdf:resource="http://sbols.org/v2#public"/>
+        <sbol:definition rdf:resource="http://liverpool.ac.uk/ComponentDefinition/P21683_20000_rbs/1"/>
+        <sbol:displayId>P21683_20000_rbs_0</sbol:displayId>
+        <sbol:persistentIdentity rdf:resource="http://liverpool.ac.uk/ComponentDefinition/P21683_20000_gene/P21683_20000_rbs_0"/>
+        <sbol:roleIntegration rdf:resource="http://sbols.org/v2#mergeRoles"/>
+        <sbol:version>1</sbol:version>
+      </sbol:Component>
+    </sbol:component>
+    <sbol:component>
+      <sbol:Component rdf:about="http://liverpool.ac.uk/ComponentDefinition/P21683_20000_gene/P21683_20000_cds_0/1">
+        <sbol:access rdf:resource="http://sbols.org/v2#public"/>
+        <sbol:definition rdf:resource="http://liverpool.ac.uk/ComponentDefinition/P21683_20000_cds/1"/>
+        <sbol:displayId>P21683_20000_cds_0</sbol:displayId>
+        <sbol:persistentIdentity rdf:resource="http://liverpool.ac.uk/ComponentDefinition/P21683_20000_gene/P21683_20000_cds_0"/>
+        <sbol:roleIntegration rdf:resource="http://sbols.org/v2#mergeRoles"/>
+        <sbol:version>1</sbol:version>
+      </sbol:Component>
+    </sbol:component>
+    <sbol:component>
+      <sbol:Component rdf:about="http://liverpool.ac.uk/ComponentDefinition/P21683_20000_gene/rxn_1_3_prime_assembly_0/1">
+        <sbol:access rdf:resource="http://sbols.org/v2#public"/>
+        <sbol:definition rdf:resource="http://liverpool.ac.uk/ComponentDefinition/rxn_1_3_prime_assembly/1"/>
+        <sbol:displayId>rxn_1_3_prime_assembly_0</sbol:displayId>
+        <sbol:persistentIdentity rdf:resource="http://liverpool.ac.uk/ComponentDefinition/P21683_20000_gene/rxn_1_3_prime_assembly_0"/>
+        <sbol:roleIntegration rdf:resource="http://sbols.org/v2#mergeRoles"/>
+        <sbol:version>1</sbol:version>
+      </sbol:Component>
+    </sbol:component>
+    <sbol:component>
+      <sbol:Component rdf:about="http://liverpool.ac.uk/ComponentDefinition/P21683_20000_gene/rxn_2_5_prime_assembly_0/1">
+        <sbol:access rdf:resource="http://sbols.org/v2#public"/>
+        <sbol:definition rdf:resource="http://liverpool.ac.uk/ComponentDefinition/rxn_2_5_prime_assembly/1"/>
+        <sbol:displayId>rxn_2_5_prime_assembly_0</sbol:displayId>
+        <sbol:persistentIdentity rdf:resource="http://liverpool.ac.uk/ComponentDefinition/P21683_20000_gene/rxn_2_5_prime_assembly_0"/>
+        <sbol:roleIntegration rdf:resource="http://sbols.org/v2#mergeRoles"/>
+        <sbol:version>1</sbol:version>
+      </sbol:Component>
+    </sbol:component>
+    <sbol:component>
+      <sbol:Component rdf:about="http://liverpool.ac.uk/ComponentDefinition/P21683_20000_gene/P21683_20000_rbs_1/1">
+        <sbol:access rdf:resource="http://sbols.org/v2#public"/>
+        <sbol:definition rdf:resource="http://liverpool.ac.uk/ComponentDefinition/P21683_20000_rbs/1"/>
+        <sbol:displayId>P21683_20000_rbs_1</sbol:displayId>
+        <sbol:persistentIdentity rdf:resource="http://liverpool.ac.uk/ComponentDefinition/P21683_20000_gene/P21683_20000_rbs_1"/>
+        <sbol:roleIntegration rdf:resource="http://sbols.org/v2#mergeRoles"/>
+        <sbol:version>1</sbol:version>
+      </sbol:Component>
+    </sbol:component>
+    <sbol:component>
+      <sbol:Component rdf:about="http://liverpool.ac.uk/ComponentDefinition/P21683_20000_gene/P21683_20000_cds_1/1">
+        <sbol:access rdf:resource="http://sbols.org/v2#public"/>
+        <sbol:definition rdf:resource="http://liverpool.ac.uk/ComponentDefinition/P21683_20000_cds/1"/>
+        <sbol:displayId>P21683_20000_cds_1</sbol:displayId>
+        <sbol:persistentIdentity rdf:resource="http://liverpool.ac.uk/ComponentDefinition/P21683_20000_gene/P21683_20000_cds_1"/>
+        <sbol:roleIntegration rdf:resource="http://sbols.org/v2#mergeRoles"/>
+        <sbol:version>1</sbol:version>
+      </sbol:Component>
+    </sbol:component>
+    <sbol:component>
+      <sbol:Component rdf:about="http://liverpool.ac.uk/ComponentDefinition/P21683_20000_gene/rxn_2_3_prime_assembly_0/1">
+        <sbol:access rdf:resource="http://sbols.org/v2#public"/>
+        <sbol:definition rdf:resource="http://liverpool.ac.uk/ComponentDefinition/rxn_2_3_prime_assembly/1"/>
+        <sbol:displayId>rxn_2_3_prime_assembly_0</sbol:displayId>
+        <sbol:persistentIdentity rdf:resource="http://liverpool.ac.uk/ComponentDefinition/P21683_20000_gene/rxn_2_3_prime_assembly_0"/>
+        <sbol:roleIntegration rdf:resource="http://sbols.org/v2#mergeRoles"/>
+        <sbol:version>1</sbol:version>
+      </sbol:Component>
+    </sbol:component>
+    <sbol:component>
+      <sbol:Component rdf:about="http://liverpool.ac.uk/ComponentDefinition/P21683_20000_gene/rxn_3_5_prime_assembly_0/1">
+        <sbol:access rdf:resource="http://sbols.org/v2#public"/>
+        <sbol:definition rdf:resource="http://liverpool.ac.uk/ComponentDefinition/rxn_3_5_prime_assembly/1"/>
+        <sbol:displayId>rxn_3_5_prime_assembly_0</sbol:displayId>
+        <sbol:persistentIdentity rdf:resource="http://liverpool.ac.uk/ComponentDefinition/P21683_20000_gene/rxn_3_5_prime_assembly_0"/>
+        <sbol:roleIntegration rdf:resource="http://sbols.org/v2#mergeRoles"/>
+        <sbol:version>1</sbol:version>
+      </sbol:Component>
+    </sbol:component>
+    <sbol:component>
+      <sbol:Component rdf:about="http://liverpool.ac.uk/ComponentDefinition/P21683_20000_gene/P21683_20000_rbs_2/1">
+        <sbol:access rdf:resource="http://sbols.org/v2#public"/>
+        <sbol:definition rdf:resource="http://liverpool.ac.uk/ComponentDefinition/P21683_20000_rbs/1"/>
+        <sbol:displayId>P21683_20000_rbs_2</sbol:displayId>
+        <sbol:persistentIdentity rdf:resource="http://liverpool.ac.uk/ComponentDefinition/P21683_20000_gene/P21683_20000_rbs_2"/>
+        <sbol:roleIntegration rdf:resource="http://sbols.org/v2#mergeRoles"/>
+        <sbol:version>1</sbol:version>
+      </sbol:Component>
+    </sbol:component>
+    <sbol:component>
+      <sbol:Component rdf:about="http://liverpool.ac.uk/ComponentDefinition/P21683_20000_gene/P21683_20000_cds_2/1">
+        <sbol:access rdf:resource="http://sbols.org/v2#public"/>
+        <sbol:definition rdf:resource="http://liverpool.ac.uk/ComponentDefinition/P21683_20000_cds/1"/>
+        <sbol:displayId>P21683_20000_cds_2</sbol:displayId>
+        <sbol:persistentIdentity rdf:resource="http://liverpool.ac.uk/ComponentDefinition/P21683_20000_gene/P21683_20000_cds_2"/>
+        <sbol:roleIntegration rdf:resource="http://sbols.org/v2#mergeRoles"/>
+        <sbol:version>1</sbol:version>
+      </sbol:Component>
+    </sbol:component>
+    <sbol:component>
+      <sbol:Component rdf:about="http://liverpool.ac.uk/ComponentDefinition/P21683_20000_gene/rxn_3_3_prime_assembly_0/1">
+        <sbol:access rdf:resource="http://sbols.org/v2#public"/>
+        <sbol:definition rdf:resource="http://liverpool.ac.uk/ComponentDefinition/rxn_3_3_prime_assembly/1"/>
+        <sbol:displayId>rxn_3_3_prime_assembly_0</sbol:displayId>
+        <sbol:persistentIdentity rdf:resource="http://liverpool.ac.uk/ComponentDefinition/P21683_20000_gene/rxn_3_3_prime_assembly_0"/>
+        <sbol:roleIntegration rdf:resource="http://sbols.org/v2#mergeRoles"/>
+        <sbol:version>1</sbol:version>
+      </sbol:Component>
+    </sbol:component>
+    <sbol:sequenceConstraint>
+      <sbol:SequenceConstraint rdf:about="http://liverpool.ac.uk/ComponentDefinition/P21683_20000_gene/constraint_0/1">
+        <sbol:displayId>constraint_0</sbol:displayId>
+        <sbol:object rdf:resource="http://liverpool.ac.uk/ComponentDefinition/P21683_20000_gene/P21683_20000_rbs_2/1"/>
+        <sbol:persistentIdentity rdf:resource="http://liverpool.ac.uk/ComponentDefinition/P21683_20000_gene/constraint_0"/>
+        <sbol:restriction rdf:resource="http://sbols.org/v2#precedes"/>
+        <sbol:subject rdf:resource="http://liverpool.ac.uk/ComponentDefinition/P21683_20000_gene/rxn_3_5_prime_assembly_0/1"/>
+        <sbol:version>1</sbol:version>
+      </sbol:SequenceConstraint>
+    </sbol:sequenceConstraint>
+    <sbol:sequenceConstraint>
+      <sbol:SequenceConstraint rdf:about="http://liverpool.ac.uk/ComponentDefinition/P21683_20000_gene/constraint_1/1">
+        <sbol:displayId>constraint_1</sbol:displayId>
+        <sbol:object rdf:resource="http://liverpool.ac.uk/ComponentDefinition/P21683_20000_gene/P21683_20000_cds_2/1"/>
+        <sbol:persistentIdentity rdf:resource="http://liverpool.ac.uk/ComponentDefinition/P21683_20000_gene/constraint_1"/>
+        <sbol:restriction rdf:resource="http://sbols.org/v2#precedes"/>
+        <sbol:subject rdf:resource="http://liverpool.ac.uk/ComponentDefinition/P21683_20000_gene/P21683_20000_rbs_2/1"/>
+        <sbol:version>1</sbol:version>
+      </sbol:SequenceConstraint>
+    </sbol:sequenceConstraint>
+    <sbol:sequenceConstraint>
+      <sbol:SequenceConstraint rdf:about="http://liverpool.ac.uk/ComponentDefinition/P21683_20000_gene/constraint_2/1">
+        <sbol:displayId>constraint_2</sbol:displayId>
+        <sbol:object rdf:resource="http://liverpool.ac.uk/ComponentDefinition/P21683_20000_gene/rxn_3_3_prime_assembly_0/1"/>
+        <sbol:persistentIdentity rdf:resource="http://liverpool.ac.uk/ComponentDefinition/P21683_20000_gene/constraint_2"/>
+        <sbol:restriction rdf:resource="http://sbols.org/v2#precedes"/>
+        <sbol:subject rdf:resource="http://liverpool.ac.uk/ComponentDefinition/P21683_20000_gene/P21683_20000_cds_2/1"/>
+        <sbol:version>1</sbol:version>
+      </sbol:SequenceConstraint>
+    </sbol:sequenceConstraint>
+  </sbol:ComponentDefinition>
+  <sbol:ComponentDefinition rdf:about="http://liverpool.ac.uk/ComponentDefinition/P21683_20000_cds/1">
+    <sbol:displayId>P21683_20000_cds</sbol:displayId>
+    <sbol:persistentIdentity rdf:resource="http://liverpool.ac.uk/ComponentDefinition/P21683_20000_cds"/>
+    <sbol:role rdf:resource="http://identifiers.org/so/SO:0000316"/>
+    <sbol:type rdf:resource="http://www.biopax.org/release/biopax-level3.owl#DnaRegion"/>
+    <sbol:version>1</sbol:version>
+  </sbol:ComponentDefinition>
+  <sbol:ComponentDefinition rdf:about="http://liverpool.ac.uk/ComponentDefinition/rxn_3_5_prime_assembly/1">
+    <sbol:displayId>rxn_3_5_prime_assembly</sbol:displayId>
+    <sbol:persistentIdentity rdf:resource="http://liverpool.ac.uk/ComponentDefinition/rxn_3_5_prime_assembly"/>
+    <sbol:role rdf:resource="http://identifiers.org/so/SO:0000143"/>
+    <sbol:type rdf:resource="http://www.biopax.org/release/biopax-level3.owl#DnaRegion"/>
+    <sbol:version>1</sbol:version>
+  </sbol:ComponentDefinition>
+  <sbol:ComponentDefinition rdf:about="http://liverpool.ac.uk/ComponentDefinition/P21688_30000_cds/1">
+    <sbol:displayId>P21688_30000_cds</sbol:displayId>
+    <sbol:persistentIdentity rdf:resource="http://liverpool.ac.uk/ComponentDefinition/P21688_30000_cds"/>
+    <sbol:role rdf:resource="http://identifiers.org/so/SO:0000316"/>
+    <sbol:type rdf:resource="http://www.biopax.org/release/biopax-level3.owl#DnaRegion"/>
+    <sbol:version>1</sbol:version>
+  </sbol:ComponentDefinition>
+  <sbol:ComponentDefinition rdf:about="http://liverpool.ac.uk/ComponentDefinition/P21683_30000_cds/1">
+    <sbol:displayId>P21683_30000_cds</sbol:displayId>
+    <sbol:persistentIdentity rdf:resource="http://liverpool.ac.uk/ComponentDefinition/P21683_30000_cds"/>
+    <sbol:role rdf:resource="http://identifiers.org/so/SO:0000316"/>
+    <sbol:type rdf:resource="http://www.biopax.org/release/biopax-level3.owl#DnaRegion"/>
+    <sbol:version>1</sbol:version>
+  </sbol:ComponentDefinition>
+  <sbol:ComponentDefinition rdf:about="http://liverpool.ac.uk/ComponentDefinition/P21684_30000_rbs/1">
+    <sbol:displayId>P21684_30000_rbs</sbol:displayId>
+    <sbol:persistentIdentity rdf:resource="http://liverpool.ac.uk/ComponentDefinition/P21684_30000_rbs"/>
+    <sbol:role rdf:resource="http://identifiers.org/so/SO:0000139"/>
+    <sbol:type rdf:resource="http://www.biopax.org/release/biopax-level3.owl#DnaRegion"/>
+    <sbol:version>1</sbol:version>
+  </sbol:ComponentDefinition>
+  <sbol:ComponentDefinition rdf:about="http://liverpool.ac.uk/ComponentDefinition/P21687_30000_cds/1">
+    <sbol:displayId>P21687_30000_cds</sbol:displayId>
+    <sbol:persistentIdentity rdf:resource="http://liverpool.ac.uk/ComponentDefinition/P21687_30000_cds"/>
+    <sbol:role rdf:resource="http://identifiers.org/so/SO:0000316"/>
+    <sbol:type rdf:resource="http://www.biopax.org/release/biopax-level3.owl#DnaRegion"/>
+    <sbol:version>1</sbol:version>
+  </sbol:ComponentDefinition>
+  <sbol:ComponentDefinition rdf:about="http://liverpool.ac.uk/ComponentDefinition/P21683_10000_gene/1">
+    <sbol:displayId>P21683_10000_gene</sbol:displayId>
+    <sbol:persistentIdentity rdf:resource="http://liverpool.ac.uk/ComponentDefinition/P21683_10000_gene"/>
+    <sbol:role rdf:resource="http://identifiers.org/so/SO:0000704"/>
+    <sbol:type rdf:resource="http://www.biopax.org/release/biopax-level3.owl#DnaRegion"/>
+    <sbol:type rdf:resource="http://identifiers.org/so/SO:0000987"/>
+    <sbol:type rdf:resource="http://identifiers.org/so/SO:0000987"/>
+    <sbol:type rdf:resource="http://identifiers.org/so/SO:0000987"/>
+    <sbol:version>1</sbol:version>
+    <sbol:component>
+      <sbol:Component rdf:about="http://liverpool.ac.uk/ComponentDefinition/P21683_10000_gene/rxn_1_5_prime_assembly_0/1">
+        <sbol:access rdf:resource="http://sbols.org/v2#public"/>
+        <sbol:definition rdf:resource="http://liverpool.ac.uk/ComponentDefinition/rxn_1_5_prime_assembly/1"/>
+        <sbol:displayId>rxn_1_5_prime_assembly_0</sbol:displayId>
+        <sbol:persistentIdentity rdf:resource="http://liverpool.ac.uk/ComponentDefinition/P21683_10000_gene/rxn_1_5_prime_assembly_0"/>
+        <sbol:roleIntegration rdf:resource="http://sbols.org/v2#mergeRoles"/>
+        <sbol:version>1</sbol:version>
+      </sbol:Component>
+    </sbol:component>
+    <sbol:component>
+      <sbol:Component rdf:about="http://liverpool.ac.uk/ComponentDefinition/P21683_10000_gene/P21683_10000_rbs_0/1">
+        <sbol:access rdf:resource="http://sbols.org/v2#public"/>
+        <sbol:definition rdf:resource="http://liverpool.ac.uk/ComponentDefinition/P21683_10000_rbs/1"/>
+        <sbol:displayId>P21683_10000_rbs_0</sbol:displayId>
+        <sbol:persistentIdentity rdf:resource="http://liverpool.ac.uk/ComponentDefinition/P21683_10000_gene/P21683_10000_rbs_0"/>
+        <sbol:roleIntegration rdf:resource="http://sbols.org/v2#mergeRoles"/>
+        <sbol:version>1</sbol:version>
+      </sbol:Component>
+    </sbol:component>
+    <sbol:component>
+      <sbol:Component rdf:about="http://liverpool.ac.uk/ComponentDefinition/P21683_10000_gene/P21683_10000_cds_0/1">
+        <sbol:access rdf:resource="http://sbols.org/v2#public"/>
+        <sbol:definition rdf:resource="http://liverpool.ac.uk/ComponentDefinition/P21683_10000_cds/1"/>
+        <sbol:displayId>P21683_10000_cds_0</sbol:displayId>
+        <sbol:persistentIdentity rdf:resource="http://liverpool.ac.uk/ComponentDefinition/P21683_10000_gene/P21683_10000_cds_0"/>
+        <sbol:roleIntegration rdf:resource="http://sbols.org/v2#mergeRoles"/>
+        <sbol:version>1</sbol:version>
+      </sbol:Component>
+    </sbol:component>
+    <sbol:component>
+      <sbol:Component rdf:about="http://liverpool.ac.uk/ComponentDefinition/P21683_10000_gene/rxn_1_3_prime_assembly_0/1">
+        <sbol:access rdf:resource="http://sbols.org/v2#public"/>
+        <sbol:definition rdf:resource="http://liverpool.ac.uk/ComponentDefinition/rxn_1_3_prime_assembly/1"/>
+        <sbol:displayId>rxn_1_3_prime_assembly_0</sbol:displayId>
+        <sbol:persistentIdentity rdf:resource="http://liverpool.ac.uk/ComponentDefinition/P21683_10000_gene/rxn_1_3_prime_assembly_0"/>
+        <sbol:roleIntegration rdf:resource="http://sbols.org/v2#mergeRoles"/>
+        <sbol:version>1</sbol:version>
+      </sbol:Component>
+    </sbol:component>
+    <sbol:component>
+      <sbol:Component rdf:about="http://liverpool.ac.uk/ComponentDefinition/P21683_10000_gene/rxn_2_5_prime_assembly_0/1">
+        <sbol:access rdf:resource="http://sbols.org/v2#public"/>
+        <sbol:definition rdf:resource="http://liverpool.ac.uk/ComponentDefinition/rxn_2_5_prime_assembly/1"/>
+        <sbol:displayId>rxn_2_5_prime_assembly_0</sbol:displayId>
+        <sbol:persistentIdentity rdf:resource="http://liverpool.ac.uk/ComponentDefinition/P21683_10000_gene/rxn_2_5_prime_assembly_0"/>
+        <sbol:roleIntegration rdf:resource="http://sbols.org/v2#mergeRoles"/>
+        <sbol:version>1</sbol:version>
+      </sbol:Component>
+    </sbol:component>
+    <sbol:component>
+      <sbol:Component rdf:about="http://liverpool.ac.uk/ComponentDefinition/P21683_10000_gene/P21683_10000_rbs_1/1">
+        <sbol:access rdf:resource="http://sbols.org/v2#public"/>
+        <sbol:definition rdf:resource="http://liverpool.ac.uk/ComponentDefinition/P21683_10000_rbs/1"/>
+        <sbol:displayId>P21683_10000_rbs_1</sbol:displayId>
+        <sbol:persistentIdentity rdf:resource="http://liverpool.ac.uk/ComponentDefinition/P21683_10000_gene/P21683_10000_rbs_1"/>
+        <sbol:roleIntegration rdf:resource="http://sbols.org/v2#mergeRoles"/>
+        <sbol:version>1</sbol:version>
+      </sbol:Component>
+    </sbol:component>
+    <sbol:component>
+      <sbol:Component rdf:about="http://liverpool.ac.uk/ComponentDefinition/P21683_10000_gene/P21683_10000_cds_1/1">
+        <sbol:access rdf:resource="http://sbols.org/v2#public"/>
+        <sbol:definition rdf:resource="http://liverpool.ac.uk/ComponentDefinition/P21683_10000_cds/1"/>
+        <sbol:displayId>P21683_10000_cds_1</sbol:displayId>
+        <sbol:persistentIdentity rdf:resource="http://liverpool.ac.uk/ComponentDefinition/P21683_10000_gene/P21683_10000_cds_1"/>
+        <sbol:roleIntegration rdf:resource="http://sbols.org/v2#mergeRoles"/>
+        <sbol:version>1</sbol:version>
+      </sbol:Component>
+    </sbol:component>
+    <sbol:component>
+      <sbol:Component rdf:about="http://liverpool.ac.uk/ComponentDefinition/P21683_10000_gene/rxn_2_3_prime_assembly_0/1">
+        <sbol:access rdf:resource="http://sbols.org/v2#public"/>
+        <sbol:definition rdf:resource="http://liverpool.ac.uk/ComponentDefinition/rxn_2_3_prime_assembly/1"/>
+        <sbol:displayId>rxn_2_3_prime_assembly_0</sbol:displayId>
+        <sbol:persistentIdentity rdf:resource="http://liverpool.ac.uk/ComponentDefinition/P21683_10000_gene/rxn_2_3_prime_assembly_0"/>
+        <sbol:roleIntegration rdf:resource="http://sbols.org/v2#mergeRoles"/>
+        <sbol:version>1</sbol:version>
+      </sbol:Component>
+    </sbol:component>
+    <sbol:component>
+      <sbol:Component rdf:about="http://liverpool.ac.uk/ComponentDefinition/P21683_10000_gene/rxn_3_5_prime_assembly_0/1">
+        <sbol:access rdf:resource="http://sbols.org/v2#public"/>
+        <sbol:definition rdf:resource="http://liverpool.ac.uk/ComponentDefinition/rxn_3_5_prime_assembly/1"/>
+        <sbol:displayId>rxn_3_5_prime_assembly_0</sbol:displayId>
+        <sbol:persistentIdentity rdf:resource="http://liverpool.ac.uk/ComponentDefinition/P21683_10000_gene/rxn_3_5_prime_assembly_0"/>
+        <sbol:roleIntegration rdf:resource="http://sbols.org/v2#mergeRoles"/>
+        <sbol:version>1</sbol:version>
+      </sbol:Component>
+    </sbol:component>
+    <sbol:component>
+      <sbol:Component rdf:about="http://liverpool.ac.uk/ComponentDefinition/P21683_10000_gene/P21683_10000_rbs_2/1">
+        <sbol:access rdf:resource="http://sbols.org/v2#public"/>
+        <sbol:definition rdf:resource="http://liverpool.ac.uk/ComponentDefinition/P21683_10000_rbs/1"/>
+        <sbol:displayId>P21683_10000_rbs_2</sbol:displayId>
+        <sbol:persistentIdentity rdf:resource="http://liverpool.ac.uk/ComponentDefinition/P21683_10000_gene/P21683_10000_rbs_2"/>
+        <sbol:roleIntegration rdf:resource="http://sbols.org/v2#mergeRoles"/>
+        <sbol:version>1</sbol:version>
+      </sbol:Component>
+    </sbol:component>
+    <sbol:component>
+      <sbol:Component rdf:about="http://liverpool.ac.uk/ComponentDefinition/P21683_10000_gene/P21683_10000_cds_2/1">
+        <sbol:access rdf:resource="http://sbols.org/v2#public"/>
+        <sbol:definition rdf:resource="http://liverpool.ac.uk/ComponentDefinition/P21683_10000_cds/1"/>
+        <sbol:displayId>P21683_10000_cds_2</sbol:displayId>
+        <sbol:persistentIdentity rdf:resource="http://liverpool.ac.uk/ComponentDefinition/P21683_10000_gene/P21683_10000_cds_2"/>
+        <sbol:roleIntegration rdf:resource="http://sbols.org/v2#mergeRoles"/>
+        <sbol:version>1</sbol:version>
+      </sbol:Component>
+    </sbol:component>
+    <sbol:component>
+      <sbol:Component rdf:about="http://liverpool.ac.uk/ComponentDefinition/P21683_10000_gene/rxn_3_3_prime_assembly_0/1">
+        <sbol:access rdf:resource="http://sbols.org/v2#public"/>
+        <sbol:definition rdf:resource="http://liverpool.ac.uk/ComponentDefinition/rxn_3_3_prime_assembly/1"/>
+        <sbol:displayId>rxn_3_3_prime_assembly_0</sbol:displayId>
+        <sbol:persistentIdentity rdf:resource="http://liverpool.ac.uk/ComponentDefinition/P21683_10000_gene/rxn_3_3_prime_assembly_0"/>
+        <sbol:roleIntegration rdf:resource="http://sbols.org/v2#mergeRoles"/>
+        <sbol:version>1</sbol:version>
+      </sbol:Component>
+    </sbol:component>
+    <sbol:sequenceConstraint>
+      <sbol:SequenceConstraint rdf:about="http://liverpool.ac.uk/ComponentDefinition/P21683_10000_gene/constraint_0/1">
+        <sbol:displayId>constraint_0</sbol:displayId>
+        <sbol:object rdf:resource="http://liverpool.ac.uk/ComponentDefinition/P21683_10000_gene/P21683_10000_rbs_2/1"/>
+        <sbol:persistentIdentity rdf:resource="http://liverpool.ac.uk/ComponentDefinition/P21683_10000_gene/constraint_0"/>
+        <sbol:restriction rdf:resource="http://sbols.org/v2#precedes"/>
+        <sbol:subject rdf:resource="http://liverpool.ac.uk/ComponentDefinition/P21683_10000_gene/rxn_3_5_prime_assembly_0/1"/>
+        <sbol:version>1</sbol:version>
+      </sbol:SequenceConstraint>
+    </sbol:sequenceConstraint>
+    <sbol:sequenceConstraint>
+      <sbol:SequenceConstraint rdf:about="http://liverpool.ac.uk/ComponentDefinition/P21683_10000_gene/constraint_1/1">
+        <sbol:displayId>constraint_1</sbol:displayId>
+        <sbol:object rdf:resource="http://liverpool.ac.uk/ComponentDefinition/P21683_10000_gene/P21683_10000_cds_2/1"/>
+        <sbol:persistentIdentity rdf:resource="http://liverpool.ac.uk/ComponentDefinition/P21683_10000_gene/constraint_1"/>
+        <sbol:restriction rdf:resource="http://sbols.org/v2#precedes"/>
+        <sbol:subject rdf:resource="http://liverpool.ac.uk/ComponentDefinition/P21683_10000_gene/P21683_10000_rbs_2/1"/>
+        <sbol:version>1</sbol:version>
+      </sbol:SequenceConstraint>
+    </sbol:sequenceConstraint>
+    <sbol:sequenceConstraint>
+      <sbol:SequenceConstraint rdf:about="http://liverpool.ac.uk/ComponentDefinition/P21683_10000_gene/constraint_2/1">
+        <sbol:displayId>constraint_2</sbol:displayId>
+        <sbol:object rdf:resource="http://liverpool.ac.uk/ComponentDefinition/P21683_10000_gene/rxn_3_3_prime_assembly_0/1"/>
+        <sbol:persistentIdentity rdf:resource="http://liverpool.ac.uk/ComponentDefinition/P21683_10000_gene/constraint_2"/>
+        <sbol:restriction rdf:resource="http://sbols.org/v2#precedes"/>
+        <sbol:subject rdf:resource="http://liverpool.ac.uk/ComponentDefinition/P21683_10000_gene/P21683_10000_cds_2/1"/>
+        <sbol:version>1</sbol:version>
+      </sbol:SequenceConstraint>
+    </sbol:sequenceConstraint>
+  </sbol:ComponentDefinition>
+  <sbol:ComponentDefinition rdf:about="http://liverpool.ac.uk/ComponentDefinition/P21683_10000_cds/1">
+    <sbol:displayId>P21683_10000_cds</sbol:displayId>
+    <sbol:persistentIdentity rdf:resource="http://liverpool.ac.uk/ComponentDefinition/P21683_10000_cds"/>
+    <sbol:role rdf:resource="http://identifiers.org/so/SO:0000316"/>
+    <sbol:type rdf:resource="http://www.biopax.org/release/biopax-level3.owl#DnaRegion"/>
+    <sbol:version>1</sbol:version>
+  </sbol:ComponentDefinition>
+  <sbol:ComponentDefinition rdf:about="http://liverpool.ac.uk/ComponentDefinition/rxn_3_3_prime_assembly/1">
+    <sbol:displayId>rxn_3_3_prime_assembly</sbol:displayId>
+    <sbol:persistentIdentity rdf:resource="http://liverpool.ac.uk/ComponentDefinition/rxn_3_3_prime_assembly"/>
+    <sbol:role rdf:resource="http://identifiers.org/so/SO:0000143"/>
+    <sbol:type rdf:resource="http://www.biopax.org/release/biopax-level3.owl#DnaRegion"/>
+    <sbol:version>1</sbol:version>
+  </sbol:ComponentDefinition>
+  <sbol:ComponentDefinition rdf:about="http://liverpool.ac.uk/ComponentDefinition/P21683_10000_rbs/1">
+    <sbol:displayId>P21683_10000_rbs</sbol:displayId>
+    <sbol:persistentIdentity rdf:resource="http://liverpool.ac.uk/ComponentDefinition/P21683_10000_rbs"/>
+    <sbol:role rdf:resource="http://identifiers.org/so/SO:0000139"/>
+    <sbol:type rdf:resource="http://www.biopax.org/release/biopax-level3.owl#DnaRegion"/>
+    <sbol:version>1</sbol:version>
+  </sbol:ComponentDefinition>
+  <sbol:ComponentDefinition rdf:about="http://liverpool.ac.uk/ComponentDefinition/P21684_10000_gene/1">
+    <sbol:displayId>P21684_10000_gene</sbol:displayId>
+    <sbol:persistentIdentity rdf:resource="http://liverpool.ac.uk/ComponentDefinition/P21684_10000_gene"/>
+    <sbol:role rdf:resource="http://identifiers.org/so/SO:0000704"/>
+    <sbol:type rdf:resource="http://www.biopax.org/release/biopax-level3.owl#DnaRegion"/>
+    <sbol:type rdf:resource="http://identifiers.org/so/SO:0000987"/>
+    <sbol:type rdf:resource="http://identifiers.org/so/SO:0000987"/>
+    <sbol:version>1</sbol:version>
+    <sbol:component>
+      <sbol:Component rdf:about="http://liverpool.ac.uk/ComponentDefinition/P21684_10000_gene/rxn_1_5_prime_assembly_0/1">
+        <sbol:access rdf:resource="http://sbols.org/v2#public"/>
+        <sbol:definition rdf:resource="http://liverpool.ac.uk/ComponentDefinition/rxn_1_5_prime_assembly/1"/>
+        <sbol:displayId>rxn_1_5_prime_assembly_0</sbol:displayId>
+        <sbol:persistentIdentity rdf:resource="http://liverpool.ac.uk/ComponentDefinition/P21684_10000_gene/rxn_1_5_prime_assembly_0"/>
+        <sbol:roleIntegration rdf:resource="http://sbols.org/v2#mergeRoles"/>
+        <sbol:version>1</sbol:version>
+      </sbol:Component>
+    </sbol:component>
+    <sbol:component>
+      <sbol:Component rdf:about="http://liverpool.ac.uk/ComponentDefinition/P21684_10000_gene/P21684_10000_rbs_0/1">
+        <sbol:access rdf:resource="http://sbols.org/v2#public"/>
+        <sbol:definition rdf:resource="http://liverpool.ac.uk/ComponentDefinition/P21684_10000_rbs/1"/>
+        <sbol:displayId>P21684_10000_rbs_0</sbol:displayId>
+        <sbol:persistentIdentity rdf:resource="http://liverpool.ac.uk/ComponentDefinition/P21684_10000_gene/P21684_10000_rbs_0"/>
+        <sbol:roleIntegration rdf:resource="http://sbols.org/v2#mergeRoles"/>
+        <sbol:version>1</sbol:version>
+      </sbol:Component>
+    </sbol:component>
+    <sbol:component>
+      <sbol:Component rdf:about="http://liverpool.ac.uk/ComponentDefinition/P21684_10000_gene/P21684_10000_cds_0/1">
+        <sbol:access rdf:resource="http://sbols.org/v2#public"/>
+        <sbol:definition rdf:resource="http://liverpool.ac.uk/ComponentDefinition/P21684_10000_cds/1"/>
+        <sbol:displayId>P21684_10000_cds_0</sbol:displayId>
+        <sbol:persistentIdentity rdf:resource="http://liverpool.ac.uk/ComponentDefinition/P21684_10000_gene/P21684_10000_cds_0"/>
+        <sbol:roleIntegration rdf:resource="http://sbols.org/v2#mergeRoles"/>
+        <sbol:version>1</sbol:version>
+      </sbol:Component>
+    </sbol:component>
+    <sbol:component>
+      <sbol:Component rdf:about="http://liverpool.ac.uk/ComponentDefinition/P21684_10000_gene/rxn_1_3_prime_assembly_0/1">
+        <sbol:access rdf:resource="http://sbols.org/v2#public"/>
+        <sbol:definition rdf:resource="http://liverpool.ac.uk/ComponentDefinition/rxn_1_3_prime_assembly/1"/>
+        <sbol:displayId>rxn_1_3_prime_assembly_0</sbol:displayId>
+        <sbol:persistentIdentity rdf:resource="http://liverpool.ac.uk/ComponentDefinition/P21684_10000_gene/rxn_1_3_prime_assembly_0"/>
+        <sbol:roleIntegration rdf:resource="http://sbols.org/v2#mergeRoles"/>
+        <sbol:version>1</sbol:version>
+      </sbol:Component>
+    </sbol:component>
+    <sbol:component>
+      <sbol:Component rdf:about="http://liverpool.ac.uk/ComponentDefinition/P21684_10000_gene/rxn_2_5_prime_assembly_0/1">
+        <sbol:access rdf:resource="http://sbols.org/v2#public"/>
+        <sbol:definition rdf:resource="http://liverpool.ac.uk/ComponentDefinition/rxn_2_5_prime_assembly/1"/>
+        <sbol:displayId>rxn_2_5_prime_assembly_0</sbol:displayId>
+        <sbol:persistentIdentity rdf:resource="http://liverpool.ac.uk/ComponentDefinition/P21684_10000_gene/rxn_2_5_prime_assembly_0"/>
+        <sbol:roleIntegration rdf:resource="http://sbols.org/v2#mergeRoles"/>
+        <sbol:version>1</sbol:version>
+      </sbol:Component>
+    </sbol:component>
+    <sbol:component>
+      <sbol:Component rdf:about="http://liverpool.ac.uk/ComponentDefinition/P21684_10000_gene/P21684_10000_rbs_1/1">
+        <sbol:access rdf:resource="http://sbols.org/v2#public"/>
+        <sbol:definition rdf:resource="http://liverpool.ac.uk/ComponentDefinition/P21684_10000_rbs/1"/>
+        <sbol:displayId>P21684_10000_rbs_1</sbol:displayId>
+        <sbol:persistentIdentity rdf:resource="http://liverpool.ac.uk/ComponentDefinition/P21684_10000_gene/P21684_10000_rbs_1"/>
+        <sbol:roleIntegration rdf:resource="http://sbols.org/v2#mergeRoles"/>
+        <sbol:version>1</sbol:version>
+      </sbol:Component>
+    </sbol:component>
+    <sbol:component>
+      <sbol:Component rdf:about="http://liverpool.ac.uk/ComponentDefinition/P21684_10000_gene/P21684_10000_cds_1/1">
+        <sbol:access rdf:resource="http://sbols.org/v2#public"/>
+        <sbol:definition rdf:resource="http://liverpool.ac.uk/ComponentDefinition/P21684_10000_cds/1"/>
+        <sbol:displayId>P21684_10000_cds_1</sbol:displayId>
+        <sbol:persistentIdentity rdf:resource="http://liverpool.ac.uk/ComponentDefinition/P21684_10000_gene/P21684_10000_cds_1"/>
+        <sbol:roleIntegration rdf:resource="http://sbols.org/v2#mergeRoles"/>
+        <sbol:version>1</sbol:version>
+      </sbol:Component>
+    </sbol:component>
+    <sbol:component>
+      <sbol:Component rdf:about="http://liverpool.ac.uk/ComponentDefinition/P21684_10000_gene/rxn_2_3_prime_assembly_0/1">
+        <sbol:access rdf:resource="http://sbols.org/v2#public"/>
+        <sbol:definition rdf:resource="http://liverpool.ac.uk/ComponentDefinition/rxn_2_3_prime_assembly/1"/>
+        <sbol:displayId>rxn_2_3_prime_assembly_0</sbol:displayId>
+        <sbol:persistentIdentity rdf:resource="http://liverpool.ac.uk/ComponentDefinition/P21684_10000_gene/rxn_2_3_prime_assembly_0"/>
+        <sbol:roleIntegration rdf:resource="http://sbols.org/v2#mergeRoles"/>
+        <sbol:version>1</sbol:version>
+      </sbol:Component>
+    </sbol:component>
+    <sbol:sequenceConstraint>
+      <sbol:SequenceConstraint rdf:about="http://liverpool.ac.uk/ComponentDefinition/P21684_10000_gene/constraint_0/1">
+        <sbol:displayId>constraint_0</sbol:displayId>
+        <sbol:object rdf:resource="http://liverpool.ac.uk/ComponentDefinition/P21684_10000_gene/P21684_10000_rbs_1/1"/>
+        <sbol:persistentIdentity rdf:resource="http://liverpool.ac.uk/ComponentDefinition/P21684_10000_gene/constraint_0"/>
+        <sbol:restriction rdf:resource="http://sbols.org/v2#precedes"/>
+        <sbol:subject rdf:resource="http://liverpool.ac.uk/ComponentDefinition/P21684_10000_gene/rxn_2_5_prime_assembly_0/1"/>
+        <sbol:version>1</sbol:version>
+      </sbol:SequenceConstraint>
+    </sbol:sequenceConstraint>
+    <sbol:sequenceConstraint>
+      <sbol:SequenceConstraint rdf:about="http://liverpool.ac.uk/ComponentDefinition/P21684_10000_gene/constraint_1/1">
+        <sbol:displayId>constraint_1</sbol:displayId>
+        <sbol:object rdf:resource="http://liverpool.ac.uk/ComponentDefinition/P21684_10000_gene/P21684_10000_cds_1/1"/>
+        <sbol:persistentIdentity rdf:resource="http://liverpool.ac.uk/ComponentDefinition/P21684_10000_gene/constraint_1"/>
+        <sbol:restriction rdf:resource="http://sbols.org/v2#precedes"/>
+        <sbol:subject rdf:resource="http://liverpool.ac.uk/ComponentDefinition/P21684_10000_gene/P21684_10000_rbs_1/1"/>
+        <sbol:version>1</sbol:version>
+      </sbol:SequenceConstraint>
+    </sbol:sequenceConstraint>
+    <sbol:sequenceConstraint>
+      <sbol:SequenceConstraint rdf:about="http://liverpool.ac.uk/ComponentDefinition/P21684_10000_gene/constraint_2/1">
+        <sbol:displayId>constraint_2</sbol:displayId>
+        <sbol:object rdf:resource="http://liverpool.ac.uk/ComponentDefinition/P21684_10000_gene/rxn_2_3_prime_assembly_0/1"/>
+        <sbol:persistentIdentity rdf:resource="http://liverpool.ac.uk/ComponentDefinition/P21684_10000_gene/constraint_2"/>
+        <sbol:restriction rdf:resource="http://sbols.org/v2#precedes"/>
+        <sbol:subject rdf:resource="http://liverpool.ac.uk/ComponentDefinition/P21684_10000_gene/P21684_10000_cds_1/1"/>
+        <sbol:version>1</sbol:version>
+      </sbol:SequenceConstraint>
+    </sbol:sequenceConstraint>
+  </sbol:ComponentDefinition>
+  <sbol:ComponentDefinition rdf:about="http://liverpool.ac.uk/ComponentDefinition/P21683_20000_rbs/1">
+    <sbol:displayId>P21683_20000_rbs</sbol:displayId>
+    <sbol:persistentIdentity rdf:resource="http://liverpool.ac.uk/ComponentDefinition/P21683_20000_rbs"/>
+    <sbol:role rdf:resource="http://identifiers.org/so/SO:0000139"/>
+    <sbol:type rdf:resource="http://www.biopax.org/release/biopax-level3.owl#DnaRegion"/>
+    <sbol:version>1</sbol:version>
+  </sbol:ComponentDefinition>
+  <sbol:ComponentDefinition rdf:about="http://liverpool.ac.uk/ComponentDefinition/P21687_30000_gene/1">
+    <sbol:displayId>P21687_30000_gene</sbol:displayId>
+    <sbol:persistentIdentity rdf:resource="http://liverpool.ac.uk/ComponentDefinition/P21687_30000_gene"/>
+    <sbol:role rdf:resource="http://identifiers.org/so/SO:0000704"/>
+    <sbol:type rdf:resource="http://www.biopax.org/release/biopax-level3.owl#DnaRegion"/>
+    <sbol:type rdf:resource="http://identifiers.org/so/SO:0000987"/>
+    <sbol:version>1</sbol:version>
+    <sbol:component>
+      <sbol:Component rdf:about="http://liverpool.ac.uk/ComponentDefinition/P21687_30000_gene/rxn_3_5_prime_assembly_0/1">
+        <sbol:access rdf:resource="http://sbols.org/v2#public"/>
+        <sbol:definition rdf:resource="http://liverpool.ac.uk/ComponentDefinition/rxn_3_5_prime_assembly/1"/>
+        <sbol:displayId>rxn_3_5_prime_assembly_0</sbol:displayId>
+        <sbol:persistentIdentity rdf:resource="http://liverpool.ac.uk/ComponentDefinition/P21687_30000_gene/rxn_3_5_prime_assembly_0"/>
+        <sbol:roleIntegration rdf:resource="http://sbols.org/v2#mergeRoles"/>
+        <sbol:version>1</sbol:version>
+      </sbol:Component>
+    </sbol:component>
+    <sbol:component>
+      <sbol:Component rdf:about="http://liverpool.ac.uk/ComponentDefinition/P21687_30000_gene/P21687_30000_rbs_0/1">
+        <sbol:access rdf:resource="http://sbols.org/v2#public"/>
+        <sbol:definition rdf:resource="http://liverpool.ac.uk/ComponentDefinition/P21687_30000_rbs/1"/>
+        <sbol:displayId>P21687_30000_rbs_0</sbol:displayId>
+        <sbol:persistentIdentity rdf:resource="http://liverpool.ac.uk/ComponentDefinition/P21687_30000_gene/P21687_30000_rbs_0"/>
+        <sbol:roleIntegration rdf:resource="http://sbols.org/v2#mergeRoles"/>
+        <sbol:version>1</sbol:version>
+      </sbol:Component>
+    </sbol:component>
+    <sbol:component>
+      <sbol:Component rdf:about="http://liverpool.ac.uk/ComponentDefinition/P21687_30000_gene/P21687_30000_cds_0/1">
+        <sbol:access rdf:resource="http://sbols.org/v2#public"/>
+        <sbol:definition rdf:resource="http://liverpool.ac.uk/ComponentDefinition/P21687_30000_cds/1"/>
+        <sbol:displayId>P21687_30000_cds_0</sbol:displayId>
+        <sbol:persistentIdentity rdf:resource="http://liverpool.ac.uk/ComponentDefinition/P21687_30000_gene/P21687_30000_cds_0"/>
+        <sbol:roleIntegration rdf:resource="http://sbols.org/v2#mergeRoles"/>
+        <sbol:version>1</sbol:version>
+      </sbol:Component>
+    </sbol:component>
+    <sbol:component>
+      <sbol:Component rdf:about="http://liverpool.ac.uk/ComponentDefinition/P21687_30000_gene/rxn_3_3_prime_assembly_0/1">
+        <sbol:access rdf:resource="http://sbols.org/v2#public"/>
+        <sbol:definition rdf:resource="http://liverpool.ac.uk/ComponentDefinition/rxn_3_3_prime_assembly/1"/>
+        <sbol:displayId>rxn_3_3_prime_assembly_0</sbol:displayId>
+        <sbol:persistentIdentity rdf:resource="http://liverpool.ac.uk/ComponentDefinition/P21687_30000_gene/rxn_3_3_prime_assembly_0"/>
+        <sbol:roleIntegration rdf:resource="http://sbols.org/v2#mergeRoles"/>
+        <sbol:version>1</sbol:version>
+      </sbol:Component>
+    </sbol:component>
+    <sbol:sequenceConstraint>
+      <sbol:SequenceConstraint rdf:about="http://liverpool.ac.uk/ComponentDefinition/P21687_30000_gene/constraint_0/1">
+        <sbol:displayId>constraint_0</sbol:displayId>
+        <sbol:object rdf:resource="http://liverpool.ac.uk/ComponentDefinition/P21687_30000_gene/P21687_30000_rbs_0/1"/>
+        <sbol:persistentIdentity rdf:resource="http://liverpool.ac.uk/ComponentDefinition/P21687_30000_gene/constraint_0"/>
+        <sbol:restriction rdf:resource="http://sbols.org/v2#precedes"/>
+        <sbol:subject rdf:resource="http://liverpool.ac.uk/ComponentDefinition/P21687_30000_gene/rxn_3_5_prime_assembly_0/1"/>
+        <sbol:version>1</sbol:version>
+      </sbol:SequenceConstraint>
+    </sbol:sequenceConstraint>
+    <sbol:sequenceConstraint>
+      <sbol:SequenceConstraint rdf:about="http://liverpool.ac.uk/ComponentDefinition/P21687_30000_gene/constraint_1/1">
+        <sbol:displayId>constraint_1</sbol:displayId>
+        <sbol:object rdf:resource="http://liverpool.ac.uk/ComponentDefinition/P21687_30000_gene/P21687_30000_cds_0/1"/>
+        <sbol:persistentIdentity rdf:resource="http://liverpool.ac.uk/ComponentDefinition/P21687_30000_gene/constraint_1"/>
+        <sbol:restriction rdf:resource="http://sbols.org/v2#precedes"/>
+        <sbol:subject rdf:resource="http://liverpool.ac.uk/ComponentDefinition/P21687_30000_gene/P21687_30000_rbs_0/1"/>
+        <sbol:version>1</sbol:version>
+      </sbol:SequenceConstraint>
+    </sbol:sequenceConstraint>
+    <sbol:sequenceConstraint>
+      <sbol:SequenceConstraint rdf:about="http://liverpool.ac.uk/ComponentDefinition/P21687_30000_gene/constraint_2/1">
+        <sbol:displayId>constraint_2</sbol:displayId>
+        <sbol:object rdf:resource="http://liverpool.ac.uk/ComponentDefinition/P21687_30000_gene/rxn_3_3_prime_assembly_0/1"/>
+        <sbol:persistentIdentity rdf:resource="http://liverpool.ac.uk/ComponentDefinition/P21687_30000_gene/constraint_2"/>
+        <sbol:restriction rdf:resource="http://sbols.org/v2#precedes"/>
+        <sbol:subject rdf:resource="http://liverpool.ac.uk/ComponentDefinition/P21687_30000_gene/P21687_30000_cds_0/1"/>
+        <sbol:version>1</sbol:version>
+      </sbol:SequenceConstraint>
+    </sbol:sequenceConstraint>
+  </sbol:ComponentDefinition>
+  <sbol:ComponentDefinition rdf:about="http://liverpool.ac.uk/ComponentDefinition/P21684_10000_rbs/1">
+    <sbol:displayId>P21684_10000_rbs</sbol:displayId>
+    <sbol:persistentIdentity rdf:resource="http://liverpool.ac.uk/ComponentDefinition/P21684_10000_rbs"/>
+    <sbol:role rdf:resource="http://identifiers.org/so/SO:0000139"/>
+    <sbol:type rdf:resource="http://www.biopax.org/release/biopax-level3.owl#DnaRegion"/>
+    <sbol:version>1</sbol:version>
+  </sbol:ComponentDefinition>
+  <sbol:ComponentDefinition rdf:about="http://liverpool.ac.uk/ComponentDefinition/P21685_30000_rbs/1">
+    <sbol:displayId>P21685_30000_rbs</sbol:displayId>
+    <sbol:persistentIdentity rdf:resource="http://liverpool.ac.uk/ComponentDefinition/P21685_30000_rbs"/>
+    <sbol:role rdf:resource="http://identifiers.org/so/SO:0000139"/>
+    <sbol:type rdf:resource="http://www.biopax.org/release/biopax-level3.owl#DnaRegion"/>
+    <sbol:version>1</sbol:version>
+  </sbol:ComponentDefinition>
+  <sbol:ComponentDefinition rdf:about="http://liverpool.ac.uk/ComponentDefinition/rxn_1_3_prime_assembly/1">
+    <sbol:displayId>rxn_1_3_prime_assembly</sbol:displayId>
+    <sbol:persistentIdentity rdf:resource="http://liverpool.ac.uk/ComponentDefinition/rxn_1_3_prime_assembly"/>
+    <sbol:role rdf:resource="http://identifiers.org/so/SO:0000143"/>
+    <sbol:type rdf:resource="http://www.biopax.org/release/biopax-level3.owl#DnaRegion"/>
+    <sbol:version>1</sbol:version>
+  </sbol:ComponentDefinition>
+  <sbol:ComponentDefinition rdf:about="http://liverpool.ac.uk/ComponentDefinition/P21685_20000_cds/1">
+    <sbol:displayId>P21685_20000_cds</sbol:displayId>
+    <sbol:persistentIdentity rdf:resource="http://liverpool.ac.uk/ComponentDefinition/P21685_20000_cds"/>
+    <sbol:role rdf:resource="http://identifiers.org/so/SO:0000316"/>
+    <sbol:type rdf:resource="http://www.biopax.org/release/biopax-level3.owl#DnaRegion"/>
+    <sbol:version>1</sbol:version>
+  </sbol:ComponentDefinition>
+  <sbol:ComponentDefinition rdf:about="http://liverpool.ac.uk/ComponentDefinition/P21687_20000_rbs/1">
+    <sbol:displayId>P21687_20000_rbs</sbol:displayId>
+    <sbol:persistentIdentity rdf:resource="http://liverpool.ac.uk/ComponentDefinition/P21687_20000_rbs"/>
+    <sbol:role rdf:resource="http://identifiers.org/so/SO:0000139"/>
+    <sbol:type rdf:resource="http://www.biopax.org/release/biopax-level3.owl#DnaRegion"/>
+    <sbol:version>1</sbol:version>
+  </sbol:ComponentDefinition>
+  <sbol:ComponentDefinition rdf:about="http://liverpool.ac.uk/ComponentDefinition/P21687_20000_gene/1">
+    <sbol:displayId>P21687_20000_gene</sbol:displayId>
+    <sbol:persistentIdentity rdf:resource="http://liverpool.ac.uk/ComponentDefinition/P21687_20000_gene"/>
+    <sbol:role rdf:resource="http://identifiers.org/so/SO:0000704"/>
+    <sbol:type rdf:resource="http://www.biopax.org/release/biopax-level3.owl#DnaRegion"/>
+    <sbol:type rdf:resource="http://identifiers.org/so/SO:0000987"/>
+    <sbol:version>1</sbol:version>
+    <sbol:component>
+      <sbol:Component rdf:about="http://liverpool.ac.uk/ComponentDefinition/P21687_20000_gene/rxn_3_5_prime_assembly_0/1">
+        <sbol:access rdf:resource="http://sbols.org/v2#public"/>
+        <sbol:definition rdf:resource="http://liverpool.ac.uk/ComponentDefinition/rxn_3_5_prime_assembly/1"/>
+        <sbol:displayId>rxn_3_5_prime_assembly_0</sbol:displayId>
+        <sbol:persistentIdentity rdf:resource="http://liverpool.ac.uk/ComponentDefinition/P21687_20000_gene/rxn_3_5_prime_assembly_0"/>
+        <sbol:roleIntegration rdf:resource="http://sbols.org/v2#mergeRoles"/>
+        <sbol:version>1</sbol:version>
+      </sbol:Component>
+    </sbol:component>
+    <sbol:component>
+      <sbol:Component rdf:about="http://liverpool.ac.uk/ComponentDefinition/P21687_20000_gene/P21687_20000_rbs_0/1">
+        <sbol:access rdf:resource="http://sbols.org/v2#public"/>
+        <sbol:definition rdf:resource="http://liverpool.ac.uk/ComponentDefinition/P21687_20000_rbs/1"/>
+        <sbol:displayId>P21687_20000_rbs_0</sbol:displayId>
+        <sbol:persistentIdentity rdf:resource="http://liverpool.ac.uk/ComponentDefinition/P21687_20000_gene/P21687_20000_rbs_0"/>
+        <sbol:roleIntegration rdf:resource="http://sbols.org/v2#mergeRoles"/>
+        <sbol:version>1</sbol:version>
+      </sbol:Component>
+    </sbol:component>
+    <sbol:component>
+      <sbol:Component rdf:about="http://liverpool.ac.uk/ComponentDefinition/P21687_20000_gene/P21687_20000_cds_0/1">
+        <sbol:access rdf:resource="http://sbols.org/v2#public"/>
+        <sbol:definition rdf:resource="http://liverpool.ac.uk/ComponentDefinition/P21687_20000_cds/1"/>
+        <sbol:displayId>P21687_20000_cds_0</sbol:displayId>
+        <sbol:persistentIdentity rdf:resource="http://liverpool.ac.uk/ComponentDefinition/P21687_20000_gene/P21687_20000_cds_0"/>
+        <sbol:roleIntegration rdf:resource="http://sbols.org/v2#mergeRoles"/>
+        <sbol:version>1</sbol:version>
+      </sbol:Component>
+    </sbol:component>
+    <sbol:component>
+      <sbol:Component rdf:about="http://liverpool.ac.uk/ComponentDefinition/P21687_20000_gene/rxn_3_3_prime_assembly_0/1">
+        <sbol:access rdf:resource="http://sbols.org/v2#public"/>
+        <sbol:definition rdf:resource="http://liverpool.ac.uk/ComponentDefinition/rxn_3_3_prime_assembly/1"/>
+        <sbol:displayId>rxn_3_3_prime_assembly_0</sbol:displayId>
+        <sbol:persistentIdentity rdf:resource="http://liverpool.ac.uk/ComponentDefinition/P21687_20000_gene/rxn_3_3_prime_assembly_0"/>
+        <sbol:roleIntegration rdf:resource="http://sbols.org/v2#mergeRoles"/>
+        <sbol:version>1</sbol:version>
+      </sbol:Component>
+    </sbol:component>
+    <sbol:sequenceConstraint>
+      <sbol:SequenceConstraint rdf:about="http://liverpool.ac.uk/ComponentDefinition/P21687_20000_gene/constraint_0/1">
+        <sbol:displayId>constraint_0</sbol:displayId>
+        <sbol:object rdf:resource="http://liverpool.ac.uk/ComponentDefinition/P21687_20000_gene/P21687_20000_rbs_0/1"/>
+        <sbol:persistentIdentity rdf:resource="http://liverpool.ac.uk/ComponentDefinition/P21687_20000_gene/constraint_0"/>
+        <sbol:restriction rdf:resource="http://sbols.org/v2#precedes"/>
+        <sbol:subject rdf:resource="http://liverpool.ac.uk/ComponentDefinition/P21687_20000_gene/rxn_3_5_prime_assembly_0/1"/>
+        <sbol:version>1</sbol:version>
+      </sbol:SequenceConstraint>
+    </sbol:sequenceConstraint>
+    <sbol:sequenceConstraint>
+      <sbol:SequenceConstraint rdf:about="http://liverpool.ac.uk/ComponentDefinition/P21687_20000_gene/constraint_1/1">
+        <sbol:displayId>constraint_1</sbol:displayId>
+        <sbol:object rdf:resource="http://liverpool.ac.uk/ComponentDefinition/P21687_20000_gene/P21687_20000_cds_0/1"/>
+        <sbol:persistentIdentity rdf:resource="http://liverpool.ac.uk/ComponentDefinition/P21687_20000_gene/constraint_1"/>
+        <sbol:restriction rdf:resource="http://sbols.org/v2#precedes"/>
+        <sbol:subject rdf:resource="http://liverpool.ac.uk/ComponentDefinition/P21687_20000_gene/P21687_20000_rbs_0/1"/>
+        <sbol:version>1</sbol:version>
+      </sbol:SequenceConstraint>
+    </sbol:sequenceConstraint>
+    <sbol:sequenceConstraint>
+      <sbol:SequenceConstraint rdf:about="http://liverpool.ac.uk/ComponentDefinition/P21687_20000_gene/constraint_2/1">
+        <sbol:displayId>constraint_2</sbol:displayId>
+        <sbol:object rdf:resource="http://liverpool.ac.uk/ComponentDefinition/P21687_20000_gene/rxn_3_3_prime_assembly_0/1"/>
+        <sbol:persistentIdentity rdf:resource="http://liverpool.ac.uk/ComponentDefinition/P21687_20000_gene/constraint_2"/>
+        <sbol:restriction rdf:resource="http://sbols.org/v2#precedes"/>
+        <sbol:subject rdf:resource="http://liverpool.ac.uk/ComponentDefinition/P21687_20000_gene/P21687_20000_cds_0/1"/>
+        <sbol:version>1</sbol:version>
+      </sbol:SequenceConstraint>
+    </sbol:sequenceConstraint>
+  </sbol:ComponentDefinition>
+  <sbol:ComponentDefinition rdf:about="http://liverpool.ac.uk/ComponentDefinition/P21687_20000_cds/1">
+    <sbol:displayId>P21687_20000_cds</sbol:displayId>
+    <sbol:persistentIdentity rdf:resource="http://liverpool.ac.uk/ComponentDefinition/P21687_20000_cds"/>
+    <sbol:role rdf:resource="http://identifiers.org/so/SO:0000316"/>
+    <sbol:type rdf:resource="http://www.biopax.org/release/biopax-level3.owl#DnaRegion"/>
+    <sbol:version>1</sbol:version>
+  </sbol:ComponentDefinition>
+  <sbol:ComponentDefinition rdf:about="http://liverpool.ac.uk/ComponentDefinition/rxn_1_5_prime_assembly/1">
+    <sbol:displayId>rxn_1_5_prime_assembly</sbol:displayId>
+    <sbol:persistentIdentity rdf:resource="http://liverpool.ac.uk/ComponentDefinition/rxn_1_5_prime_assembly"/>
+    <sbol:role rdf:resource="http://identifiers.org/so/SO:0000143"/>
+    <sbol:type rdf:resource="http://www.biopax.org/release/biopax-level3.owl#DnaRegion"/>
+    <sbol:version>1</sbol:version>
+  </sbol:ComponentDefinition>
+  <sbol:ComponentDefinition rdf:about="http://liverpool.ac.uk/ComponentDefinition/rxn_2_5_prime_assembly/1">
+    <sbol:displayId>rxn_2_5_prime_assembly</sbol:displayId>
+    <sbol:persistentIdentity rdf:resource="http://liverpool.ac.uk/ComponentDefinition/rxn_2_5_prime_assembly"/>
+    <sbol:role rdf:resource="http://identifiers.org/so/SO:0000143"/>
+    <sbol:type rdf:resource="http://www.biopax.org/release/biopax-level3.owl#DnaRegion"/>
+    <sbol:version>1</sbol:version>
+  </sbol:ComponentDefinition>
+  <sbol:ComponentDefinition rdf:about="http://liverpool.ac.uk/ComponentDefinition/P21684_20000_rbs/1">
+    <sbol:displayId>P21684_20000_rbs</sbol:displayId>
+    <sbol:persistentIdentity rdf:resource="http://liverpool.ac.uk/ComponentDefinition/P21684_20000_rbs"/>
+    <sbol:role rdf:resource="http://identifiers.org/so/SO:0000139"/>
+    <sbol:type rdf:resource="http://www.biopax.org/release/biopax-level3.owl#DnaRegion"/>
+    <sbol:version>1</sbol:version>
+  </sbol:ComponentDefinition>
+  <sbol:ComponentDefinition rdf:about="http://liverpool.ac.uk/ComponentDefinition/P21685_30000_cds/1">
+    <sbol:displayId>P21685_30000_cds</sbol:displayId>
+    <sbol:persistentIdentity rdf:resource="http://liverpool.ac.uk/ComponentDefinition/P21685_30000_cds"/>
+    <sbol:role rdf:resource="http://identifiers.org/so/SO:0000316"/>
+    <sbol:type rdf:resource="http://www.biopax.org/release/biopax-level3.owl#DnaRegion"/>
+    <sbol:version>1</sbol:version>
+  </sbol:ComponentDefinition>
+  <sbol:ComponentDefinition rdf:about="http://liverpool.ac.uk/ComponentDefinition/P21683_30000_rbs/1">
+    <sbol:displayId>P21683_30000_rbs</sbol:displayId>
+    <sbol:persistentIdentity rdf:resource="http://liverpool.ac.uk/ComponentDefinition/P21683_30000_rbs"/>
+    <sbol:role rdf:resource="http://identifiers.org/so/SO:0000139"/>
+    <sbol:type rdf:resource="http://www.biopax.org/release/biopax-level3.owl#DnaRegion"/>
+    <sbol:version>1</sbol:version>
+  </sbol:ComponentDefinition>
+  <sbol:ComponentDefinition rdf:about="http://liverpool.ac.uk/ComponentDefinition/P21684_30000_gene/1">
+    <sbol:displayId>P21684_30000_gene</sbol:displayId>
+    <sbol:persistentIdentity rdf:resource="http://liverpool.ac.uk/ComponentDefinition/P21684_30000_gene"/>
+    <sbol:role rdf:resource="http://identifiers.org/so/SO:0000704"/>
+    <sbol:type rdf:resource="http://www.biopax.org/release/biopax-level3.owl#DnaRegion"/>
+    <sbol:type rdf:resource="http://identifiers.org/so/SO:0000987"/>
+    <sbol:type rdf:resource="http://identifiers.org/so/SO:0000987"/>
+    <sbol:version>1</sbol:version>
+    <sbol:component>
+      <sbol:Component rdf:about="http://liverpool.ac.uk/ComponentDefinition/P21684_30000_gene/rxn_1_5_prime_assembly_0/1">
+        <sbol:access rdf:resource="http://sbols.org/v2#public"/>
+        <sbol:definition rdf:resource="http://liverpool.ac.uk/ComponentDefinition/rxn_1_5_prime_assembly/1"/>
+        <sbol:displayId>rxn_1_5_prime_assembly_0</sbol:displayId>
+        <sbol:persistentIdentity rdf:resource="http://liverpool.ac.uk/ComponentDefinition/P21684_30000_gene/rxn_1_5_prime_assembly_0"/>
+        <sbol:roleIntegration rdf:resource="http://sbols.org/v2#mergeRoles"/>
+        <sbol:version>1</sbol:version>
+      </sbol:Component>
+    </sbol:component>
+    <sbol:component>
+      <sbol:Component rdf:about="http://liverpool.ac.uk/ComponentDefinition/P21684_30000_gene/P21684_30000_rbs_0/1">
+        <sbol:access rdf:resource="http://sbols.org/v2#public"/>
+        <sbol:definition rdf:resource="http://liverpool.ac.uk/ComponentDefinition/P21684_30000_rbs/1"/>
+        <sbol:displayId>P21684_30000_rbs_0</sbol:displayId>
+        <sbol:persistentIdentity rdf:resource="http://liverpool.ac.uk/ComponentDefinition/P21684_30000_gene/P21684_30000_rbs_0"/>
+        <sbol:roleIntegration rdf:resource="http://sbols.org/v2#mergeRoles"/>
+        <sbol:version>1</sbol:version>
+      </sbol:Component>
+    </sbol:component>
+    <sbol:component>
+      <sbol:Component rdf:about="http://liverpool.ac.uk/ComponentDefinition/P21684_30000_gene/P21684_30000_cds_0/1">
+        <sbol:access rdf:resource="http://sbols.org/v2#public"/>
+        <sbol:definition rdf:resource="http://liverpool.ac.uk/ComponentDefinition/P21684_30000_cds/1"/>
+        <sbol:displayId>P21684_30000_cds_0</sbol:displayId>
+        <sbol:persistentIdentity rdf:resource="http://liverpool.ac.uk/ComponentDefinition/P21684_30000_gene/P21684_30000_cds_0"/>
+        <sbol:roleIntegration rdf:resource="http://sbols.org/v2#mergeRoles"/>
+        <sbol:version>1</sbol:version>
+      </sbol:Component>
+    </sbol:component>
+    <sbol:component>
+      <sbol:Component rdf:about="http://liverpool.ac.uk/ComponentDefinition/P21684_30000_gene/rxn_1_3_prime_assembly_0/1">
+        <sbol:access rdf:resource="http://sbols.org/v2#public"/>
+        <sbol:definition rdf:resource="http://liverpool.ac.uk/ComponentDefinition/rxn_1_3_prime_assembly/1"/>
+        <sbol:displayId>rxn_1_3_prime_assembly_0</sbol:displayId>
+        <sbol:persistentIdentity rdf:resource="http://liverpool.ac.uk/ComponentDefinition/P21684_30000_gene/rxn_1_3_prime_assembly_0"/>
+        <sbol:roleIntegration rdf:resource="http://sbols.org/v2#mergeRoles"/>
+        <sbol:version>1</sbol:version>
+      </sbol:Component>
+    </sbol:component>
+    <sbol:component>
+      <sbol:Component rdf:about="http://liverpool.ac.uk/ComponentDefinition/P21684_30000_gene/rxn_2_5_prime_assembly_0/1">
+        <sbol:access rdf:resource="http://sbols.org/v2#public"/>
+        <sbol:definition rdf:resource="http://liverpool.ac.uk/ComponentDefinition/rxn_2_5_prime_assembly/1"/>
+        <sbol:displayId>rxn_2_5_prime_assembly_0</sbol:displayId>
+        <sbol:persistentIdentity rdf:resource="http://liverpool.ac.uk/ComponentDefinition/P21684_30000_gene/rxn_2_5_prime_assembly_0"/>
+        <sbol:roleIntegration rdf:resource="http://sbols.org/v2#mergeRoles"/>
+        <sbol:version>1</sbol:version>
+      </sbol:Component>
+    </sbol:component>
+    <sbol:component>
+      <sbol:Component rdf:about="http://liverpool.ac.uk/ComponentDefinition/P21684_30000_gene/P21684_30000_rbs_1/1">
+        <sbol:access rdf:resource="http://sbols.org/v2#public"/>
+        <sbol:definition rdf:resource="http://liverpool.ac.uk/ComponentDefinition/P21684_30000_rbs/1"/>
+        <sbol:displayId>P21684_30000_rbs_1</sbol:displayId>
+        <sbol:persistentIdentity rdf:resource="http://liverpool.ac.uk/ComponentDefinition/P21684_30000_gene/P21684_30000_rbs_1"/>
+        <sbol:roleIntegration rdf:resource="http://sbols.org/v2#mergeRoles"/>
+        <sbol:version>1</sbol:version>
+      </sbol:Component>
+    </sbol:component>
+    <sbol:component>
+      <sbol:Component rdf:about="http://liverpool.ac.uk/ComponentDefinition/P21684_30000_gene/P21684_30000_cds_1/1">
+        <sbol:access rdf:resource="http://sbols.org/v2#public"/>
+        <sbol:definition rdf:resource="http://liverpool.ac.uk/ComponentDefinition/P21684_30000_cds/1"/>
+        <sbol:displayId>P21684_30000_cds_1</sbol:displayId>
+        <sbol:persistentIdentity rdf:resource="http://liverpool.ac.uk/ComponentDefinition/P21684_30000_gene/P21684_30000_cds_1"/>
+        <sbol:roleIntegration rdf:resource="http://sbols.org/v2#mergeRoles"/>
+        <sbol:version>1</sbol:version>
+      </sbol:Component>
+    </sbol:component>
+    <sbol:component>
+      <sbol:Component rdf:about="http://liverpool.ac.uk/ComponentDefinition/P21684_30000_gene/rxn_2_3_prime_assembly_0/1">
+        <sbol:access rdf:resource="http://sbols.org/v2#public"/>
+        <sbol:definition rdf:resource="http://liverpool.ac.uk/ComponentDefinition/rxn_2_3_prime_assembly/1"/>
+        <sbol:displayId>rxn_2_3_prime_assembly_0</sbol:displayId>
+        <sbol:persistentIdentity rdf:resource="http://liverpool.ac.uk/ComponentDefinition/P21684_30000_gene/rxn_2_3_prime_assembly_0"/>
+        <sbol:roleIntegration rdf:resource="http://sbols.org/v2#mergeRoles"/>
+        <sbol:version>1</sbol:version>
+      </sbol:Component>
+    </sbol:component>
+    <sbol:sequenceConstraint>
+      <sbol:SequenceConstraint rdf:about="http://liverpool.ac.uk/ComponentDefinition/P21684_30000_gene/constraint_0/1">
+        <sbol:displayId>constraint_0</sbol:displayId>
+        <sbol:object rdf:resource="http://liverpool.ac.uk/ComponentDefinition/P21684_30000_gene/P21684_30000_rbs_1/1"/>
+        <sbol:persistentIdentity rdf:resource="http://liverpool.ac.uk/ComponentDefinition/P21684_30000_gene/constraint_0"/>
+        <sbol:restriction rdf:resource="http://sbols.org/v2#precedes"/>
+        <sbol:subject rdf:resource="http://liverpool.ac.uk/ComponentDefinition/P21684_30000_gene/rxn_2_5_prime_assembly_0/1"/>
+        <sbol:version>1</sbol:version>
+      </sbol:SequenceConstraint>
+    </sbol:sequenceConstraint>
+    <sbol:sequenceConstraint>
+      <sbol:SequenceConstraint rdf:about="http://liverpool.ac.uk/ComponentDefinition/P21684_30000_gene/constraint_1/1">
+        <sbol:displayId>constraint_1</sbol:displayId>
+        <sbol:object rdf:resource="http://liverpool.ac.uk/ComponentDefinition/P21684_30000_gene/P21684_30000_cds_1/1"/>
+        <sbol:persistentIdentity rdf:resource="http://liverpool.ac.uk/ComponentDefinition/P21684_30000_gene/constraint_1"/>
+        <sbol:restriction rdf:resource="http://sbols.org/v2#precedes"/>
+        <sbol:subject rdf:resource="http://liverpool.ac.uk/ComponentDefinition/P21684_30000_gene/P21684_30000_rbs_1/1"/>
+        <sbol:version>1</sbol:version>
+      </sbol:SequenceConstraint>
+    </sbol:sequenceConstraint>
+    <sbol:sequenceConstraint>
+      <sbol:SequenceConstraint rdf:about="http://liverpool.ac.uk/ComponentDefinition/P21684_30000_gene/constraint_2/1">
+        <sbol:displayId>constraint_2</sbol:displayId>
+        <sbol:object rdf:resource="http://liverpool.ac.uk/ComponentDefinition/P21684_30000_gene/rxn_2_3_prime_assembly_0/1"/>
+        <sbol:persistentIdentity rdf:resource="http://liverpool.ac.uk/ComponentDefinition/P21684_30000_gene/constraint_2"/>
+        <sbol:restriction rdf:resource="http://sbols.org/v2#precedes"/>
+        <sbol:subject rdf:resource="http://liverpool.ac.uk/ComponentDefinition/P21684_30000_gene/P21684_30000_cds_1/1"/>
+        <sbol:version>1</sbol:version>
+      </sbol:SequenceConstraint>
+    </sbol:sequenceConstraint>
+  </sbol:ComponentDefinition>
+  <sbol:ComponentDefinition rdf:about="http://liverpool.ac.uk/ComponentDefinition/P21684_20000_gene/1">
+    <sbol:displayId>P21684_20000_gene</sbol:displayId>
+    <sbol:persistentIdentity rdf:resource="http://liverpool.ac.uk/ComponentDefinition/P21684_20000_gene"/>
+    <sbol:role rdf:resource="http://identifiers.org/so/SO:0000704"/>
+    <sbol:type rdf:resource="http://www.biopax.org/release/biopax-level3.owl#DnaRegion"/>
+    <sbol:type rdf:resource="http://identifiers.org/so/SO:0000987"/>
+    <sbol:type rdf:resource="http://identifiers.org/so/SO:0000987"/>
+    <sbol:version>1</sbol:version>
+    <sbol:component>
+      <sbol:Component rdf:about="http://liverpool.ac.uk/ComponentDefinition/P21684_20000_gene/rxn_1_5_prime_assembly_0/1">
+        <sbol:access rdf:resource="http://sbols.org/v2#public"/>
+        <sbol:definition rdf:resource="http://liverpool.ac.uk/ComponentDefinition/rxn_1_5_prime_assembly/1"/>
+        <sbol:displayId>rxn_1_5_prime_assembly_0</sbol:displayId>
+        <sbol:persistentIdentity rdf:resource="http://liverpool.ac.uk/ComponentDefinition/P21684_20000_gene/rxn_1_5_prime_assembly_0"/>
+        <sbol:roleIntegration rdf:resource="http://sbols.org/v2#mergeRoles"/>
+        <sbol:version>1</sbol:version>
+      </sbol:Component>
+    </sbol:component>
+    <sbol:component>
+      <sbol:Component rdf:about="http://liverpool.ac.uk/ComponentDefinition/P21684_20000_gene/P21684_20000_rbs_0/1">
+        <sbol:access rdf:resource="http://sbols.org/v2#public"/>
+        <sbol:definition rdf:resource="http://liverpool.ac.uk/ComponentDefinition/P21684_20000_rbs/1"/>
+        <sbol:displayId>P21684_20000_rbs_0</sbol:displayId>
+        <sbol:persistentIdentity rdf:resource="http://liverpool.ac.uk/ComponentDefinition/P21684_20000_gene/P21684_20000_rbs_0"/>
+        <sbol:roleIntegration rdf:resource="http://sbols.org/v2#mergeRoles"/>
+        <sbol:version>1</sbol:version>
+      </sbol:Component>
+    </sbol:component>
+    <sbol:component>
+      <sbol:Component rdf:about="http://liverpool.ac.uk/ComponentDefinition/P21684_20000_gene/P21684_20000_cds_0/1">
+        <sbol:access rdf:resource="http://sbols.org/v2#public"/>
+        <sbol:definition rdf:resource="http://liverpool.ac.uk/ComponentDefinition/P21684_20000_cds/1"/>
+        <sbol:displayId>P21684_20000_cds_0</sbol:displayId>
+        <sbol:persistentIdentity rdf:resource="http://liverpool.ac.uk/ComponentDefinition/P21684_20000_gene/P21684_20000_cds_0"/>
+        <sbol:roleIntegration rdf:resource="http://sbols.org/v2#mergeRoles"/>
+        <sbol:version>1</sbol:version>
+      </sbol:Component>
+    </sbol:component>
+    <sbol:component>
+      <sbol:Component rdf:about="http://liverpool.ac.uk/ComponentDefinition/P21684_20000_gene/rxn_1_3_prime_assembly_0/1">
+        <sbol:access rdf:resource="http://sbols.org/v2#public"/>
+        <sbol:definition rdf:resource="http://liverpool.ac.uk/ComponentDefinition/rxn_1_3_prime_assembly/1"/>
+        <sbol:displayId>rxn_1_3_prime_assembly_0</sbol:displayId>
+        <sbol:persistentIdentity rdf:resource="http://liverpool.ac.uk/ComponentDefinition/P21684_20000_gene/rxn_1_3_prime_assembly_0"/>
+        <sbol:roleIntegration rdf:resource="http://sbols.org/v2#mergeRoles"/>
+        <sbol:version>1</sbol:version>
+      </sbol:Component>
+    </sbol:component>
+    <sbol:component>
+      <sbol:Component rdf:about="http://liverpool.ac.uk/ComponentDefinition/P21684_20000_gene/rxn_2_5_prime_assembly_0/1">
+        <sbol:access rdf:resource="http://sbols.org/v2#public"/>
+        <sbol:definition rdf:resource="http://liverpool.ac.uk/ComponentDefinition/rxn_2_5_prime_assembly/1"/>
+        <sbol:displayId>rxn_2_5_prime_assembly_0</sbol:displayId>
+        <sbol:persistentIdentity rdf:resource="http://liverpool.ac.uk/ComponentDefinition/P21684_20000_gene/rxn_2_5_prime_assembly_0"/>
+        <sbol:roleIntegration rdf:resource="http://sbols.org/v2#mergeRoles"/>
+        <sbol:version>1</sbol:version>
+      </sbol:Component>
+    </sbol:component>
+    <sbol:component>
+      <sbol:Component rdf:about="http://liverpool.ac.uk/ComponentDefinition/P21684_20000_gene/P21684_20000_rbs_1/1">
+        <sbol:access rdf:resource="http://sbols.org/v2#public"/>
+        <sbol:definition rdf:resource="http://liverpool.ac.uk/ComponentDefinition/P21684_20000_rbs/1"/>
+        <sbol:displayId>P21684_20000_rbs_1</sbol:displayId>
+        <sbol:persistentIdentity rdf:resource="http://liverpool.ac.uk/ComponentDefinition/P21684_20000_gene/P21684_20000_rbs_1"/>
+        <sbol:roleIntegration rdf:resource="http://sbols.org/v2#mergeRoles"/>
+        <sbol:version>1</sbol:version>
+      </sbol:Component>
+    </sbol:component>
+    <sbol:component>
+      <sbol:Component rdf:about="http://liverpool.ac.uk/ComponentDefinition/P21684_20000_gene/P21684_20000_cds_1/1">
+        <sbol:access rdf:resource="http://sbols.org/v2#public"/>
+        <sbol:definition rdf:resource="http://liverpool.ac.uk/ComponentDefinition/P21684_20000_cds/1"/>
+        <sbol:displayId>P21684_20000_cds_1</sbol:displayId>
+        <sbol:persistentIdentity rdf:resource="http://liverpool.ac.uk/ComponentDefinition/P21684_20000_gene/P21684_20000_cds_1"/>
+        <sbol:roleIntegration rdf:resource="http://sbols.org/v2#mergeRoles"/>
+        <sbol:version>1</sbol:version>
+      </sbol:Component>
+    </sbol:component>
+    <sbol:component>
+      <sbol:Component rdf:about="http://liverpool.ac.uk/ComponentDefinition/P21684_20000_gene/rxn_2_3_prime_assembly_0/1">
+        <sbol:access rdf:resource="http://sbols.org/v2#public"/>
+        <sbol:definition rdf:resource="http://liverpool.ac.uk/ComponentDefinition/rxn_2_3_prime_assembly/1"/>
+        <sbol:displayId>rxn_2_3_prime_assembly_0</sbol:displayId>
+        <sbol:persistentIdentity rdf:resource="http://liverpool.ac.uk/ComponentDefinition/P21684_20000_gene/rxn_2_3_prime_assembly_0"/>
+        <sbol:roleIntegration rdf:resource="http://sbols.org/v2#mergeRoles"/>
+        <sbol:version>1</sbol:version>
+      </sbol:Component>
+    </sbol:component>
+    <sbol:sequenceConstraint>
+      <sbol:SequenceConstraint rdf:about="http://liverpool.ac.uk/ComponentDefinition/P21684_20000_gene/constraint_0/1">
+        <sbol:displayId>constraint_0</sbol:displayId>
+        <sbol:object rdf:resource="http://liverpool.ac.uk/ComponentDefinition/P21684_20000_gene/P21684_20000_rbs_1/1"/>
+        <sbol:persistentIdentity rdf:resource="http://liverpool.ac.uk/ComponentDefinition/P21684_20000_gene/constraint_0"/>
+        <sbol:restriction rdf:resource="http://sbols.org/v2#precedes"/>
+        <sbol:subject rdf:resource="http://liverpool.ac.uk/ComponentDefinition/P21684_20000_gene/rxn_2_5_prime_assembly_0/1"/>
+        <sbol:version>1</sbol:version>
+      </sbol:SequenceConstraint>
+    </sbol:sequenceConstraint>
+    <sbol:sequenceConstraint>
+      <sbol:SequenceConstraint rdf:about="http://liverpool.ac.uk/ComponentDefinition/P21684_20000_gene/constraint_1/1">
+        <sbol:displayId>constraint_1</sbol:displayId>
+        <sbol:object rdf:resource="http://liverpool.ac.uk/ComponentDefinition/P21684_20000_gene/P21684_20000_cds_1/1"/>
+        <sbol:persistentIdentity rdf:resource="http://liverpool.ac.uk/ComponentDefinition/P21684_20000_gene/constraint_1"/>
+        <sbol:restriction rdf:resource="http://sbols.org/v2#precedes"/>
+        <sbol:subject rdf:resource="http://liverpool.ac.uk/ComponentDefinition/P21684_20000_gene/P21684_20000_rbs_1/1"/>
+        <sbol:version>1</sbol:version>
+      </sbol:SequenceConstraint>
+    </sbol:sequenceConstraint>
+    <sbol:sequenceConstraint>
+      <sbol:SequenceConstraint rdf:about="http://liverpool.ac.uk/ComponentDefinition/P21684_20000_gene/constraint_2/1">
+        <sbol:displayId>constraint_2</sbol:displayId>
+        <sbol:object rdf:resource="http://liverpool.ac.uk/ComponentDefinition/P21684_20000_gene/rxn_2_3_prime_assembly_0/1"/>
+        <sbol:persistentIdentity rdf:resource="http://liverpool.ac.uk/ComponentDefinition/P21684_20000_gene/constraint_2"/>
+        <sbol:restriction rdf:resource="http://sbols.org/v2#precedes"/>
+        <sbol:subject rdf:resource="http://liverpool.ac.uk/ComponentDefinition/P21684_20000_gene/P21684_20000_cds_1/1"/>
+        <sbol:version>1</sbol:version>
+      </sbol:SequenceConstraint>
+    </sbol:sequenceConstraint>
+  </sbol:ComponentDefinition>
+  <sbol:ComponentDefinition rdf:about="http://liverpool.ac.uk/ComponentDefinition/P21685_10000_cds/1">
+    <sbol:displayId>P21685_10000_cds</sbol:displayId>
+    <sbol:persistentIdentity rdf:resource="http://liverpool.ac.uk/ComponentDefinition/P21685_10000_cds"/>
+    <sbol:role rdf:resource="http://identifiers.org/so/SO:0000316"/>
+    <sbol:type rdf:resource="http://www.biopax.org/release/biopax-level3.owl#DnaRegion"/>
+    <sbol:version>1</sbol:version>
+  </sbol:ComponentDefinition>
+  <sbol:ComponentDefinition rdf:about="http://liverpool.ac.uk/ComponentDefinition/P21685_10000_rbs/1">
+    <sbol:displayId>P21685_10000_rbs</sbol:displayId>
+    <sbol:persistentIdentity rdf:resource="http://liverpool.ac.uk/ComponentDefinition/P21685_10000_rbs"/>
+    <sbol:role rdf:resource="http://identifiers.org/so/SO:0000139"/>
+    <sbol:type rdf:resource="http://www.biopax.org/release/biopax-level3.owl#DnaRegion"/>
+    <sbol:version>1</sbol:version>
+  </sbol:ComponentDefinition>
+  <sbol:ComponentDefinition rdf:about="http://liverpool.ac.uk/ComponentDefinition/P21685_20000_rbs/1">
+    <sbol:displayId>P21685_20000_rbs</sbol:displayId>
+    <sbol:persistentIdentity rdf:resource="http://liverpool.ac.uk/ComponentDefinition/P21685_20000_rbs"/>
+    <sbol:role rdf:resource="http://identifiers.org/so/SO:0000139"/>
+    <sbol:type rdf:resource="http://www.biopax.org/release/biopax-level3.owl#DnaRegion"/>
+    <sbol:version>1</sbol:version>
+  </sbol:ComponentDefinition>
+  <sbol:ComponentDefinition rdf:about="http://liverpool.ac.uk/ComponentDefinition/P21688_20000_rbs/1">
+    <sbol:displayId>P21688_20000_rbs</sbol:displayId>
+    <sbol:persistentIdentity rdf:resource="http://liverpool.ac.uk/ComponentDefinition/P21688_20000_rbs"/>
+    <sbol:role rdf:resource="http://identifiers.org/so/SO:0000139"/>
+    <sbol:type rdf:resource="http://www.biopax.org/release/biopax-level3.owl#DnaRegion"/>
+    <sbol:version>1</sbol:version>
+  </sbol:ComponentDefinition>
+  <sbol:ComponentDefinition rdf:about="http://liverpool.ac.uk/ComponentDefinition/P21684_10000_cds/1">
+    <sbol:displayId>P21684_10000_cds</sbol:displayId>
+    <sbol:persistentIdentity rdf:resource="http://liverpool.ac.uk/ComponentDefinition/P21684_10000_cds"/>
+    <sbol:role rdf:resource="http://identifiers.org/so/SO:0000316"/>
+    <sbol:type rdf:resource="http://www.biopax.org/release/biopax-level3.owl#DnaRegion"/>
+    <sbol:version>1</sbol:version>
+  </sbol:ComponentDefinition>
+  <sbol:ComponentDefinition rdf:about="http://liverpool.ac.uk/ComponentDefinition/P21685_20000_gene/1">
+    <sbol:displayId>P21685_20000_gene</sbol:displayId>
+    <sbol:persistentIdentity rdf:resource="http://liverpool.ac.uk/ComponentDefinition/P21685_20000_gene"/>
+    <sbol:role rdf:resource="http://identifiers.org/so/SO:0000704"/>
+    <sbol:type rdf:resource="http://www.biopax.org/release/biopax-level3.owl#DnaRegion"/>
+    <sbol:type rdf:resource="http://identifiers.org/so/SO:0000987"/>
+    <sbol:version>1</sbol:version>
+    <sbol:component>
+      <sbol:Component rdf:about="http://liverpool.ac.uk/ComponentDefinition/P21685_20000_gene/rxn_3_5_prime_assembly_0/1">
+        <sbol:access rdf:resource="http://sbols.org/v2#public"/>
+        <sbol:definition rdf:resource="http://liverpool.ac.uk/ComponentDefinition/rxn_3_5_prime_assembly/1"/>
+        <sbol:displayId>rxn_3_5_prime_assembly_0</sbol:displayId>
+        <sbol:persistentIdentity rdf:resource="http://liverpool.ac.uk/ComponentDefinition/P21685_20000_gene/rxn_3_5_prime_assembly_0"/>
+        <sbol:roleIntegration rdf:resource="http://sbols.org/v2#mergeRoles"/>
+        <sbol:version>1</sbol:version>
+      </sbol:Component>
+    </sbol:component>
+    <sbol:component>
+      <sbol:Component rdf:about="http://liverpool.ac.uk/ComponentDefinition/P21685_20000_gene/P21685_20000_rbs_0/1">
+        <sbol:access rdf:resource="http://sbols.org/v2#public"/>
+        <sbol:definition rdf:resource="http://liverpool.ac.uk/ComponentDefinition/P21685_20000_rbs/1"/>
+        <sbol:displayId>P21685_20000_rbs_0</sbol:displayId>
+        <sbol:persistentIdentity rdf:resource="http://liverpool.ac.uk/ComponentDefinition/P21685_20000_gene/P21685_20000_rbs_0"/>
+        <sbol:roleIntegration rdf:resource="http://sbols.org/v2#mergeRoles"/>
+        <sbol:version>1</sbol:version>
+      </sbol:Component>
+    </sbol:component>
+    <sbol:component>
+      <sbol:Component rdf:about="http://liverpool.ac.uk/ComponentDefinition/P21685_20000_gene/P21685_20000_cds_0/1">
+        <sbol:access rdf:resource="http://sbols.org/v2#public"/>
+        <sbol:definition rdf:resource="http://liverpool.ac.uk/ComponentDefinition/P21685_20000_cds/1"/>
+        <sbol:displayId>P21685_20000_cds_0</sbol:displayId>
+        <sbol:persistentIdentity rdf:resource="http://liverpool.ac.uk/ComponentDefinition/P21685_20000_gene/P21685_20000_cds_0"/>
+        <sbol:roleIntegration rdf:resource="http://sbols.org/v2#mergeRoles"/>
+        <sbol:version>1</sbol:version>
+      </sbol:Component>
+    </sbol:component>
+    <sbol:component>
+      <sbol:Component rdf:about="http://liverpool.ac.uk/ComponentDefinition/P21685_20000_gene/rxn_3_3_prime_assembly_0/1">
+        <sbol:access rdf:resource="http://sbols.org/v2#public"/>
+        <sbol:definition rdf:resource="http://liverpool.ac.uk/ComponentDefinition/rxn_3_3_prime_assembly/1"/>
+        <sbol:displayId>rxn_3_3_prime_assembly_0</sbol:displayId>
+        <sbol:persistentIdentity rdf:resource="http://liverpool.ac.uk/ComponentDefinition/P21685_20000_gene/rxn_3_3_prime_assembly_0"/>
+        <sbol:roleIntegration rdf:resource="http://sbols.org/v2#mergeRoles"/>
+        <sbol:version>1</sbol:version>
+      </sbol:Component>
+    </sbol:component>
+    <sbol:sequenceConstraint>
+      <sbol:SequenceConstraint rdf:about="http://liverpool.ac.uk/ComponentDefinition/P21685_20000_gene/constraint_0/1">
+        <sbol:displayId>constraint_0</sbol:displayId>
+        <sbol:object rdf:resource="http://liverpool.ac.uk/ComponentDefinition/P21685_20000_gene/P21685_20000_rbs_0/1"/>
+        <sbol:persistentIdentity rdf:resource="http://liverpool.ac.uk/ComponentDefinition/P21685_20000_gene/constraint_0"/>
+        <sbol:restriction rdf:resource="http://sbols.org/v2#precedes"/>
+        <sbol:subject rdf:resource="http://liverpool.ac.uk/ComponentDefinition/P21685_20000_gene/rxn_3_5_prime_assembly_0/1"/>
+        <sbol:version>1</sbol:version>
+      </sbol:SequenceConstraint>
+    </sbol:sequenceConstraint>
+    <sbol:sequenceConstraint>
+      <sbol:SequenceConstraint rdf:about="http://liverpool.ac.uk/ComponentDefinition/P21685_20000_gene/constraint_1/1">
+        <sbol:displayId>constraint_1</sbol:displayId>
+        <sbol:object rdf:resource="http://liverpool.ac.uk/ComponentDefinition/P21685_20000_gene/P21685_20000_cds_0/1"/>
+        <sbol:persistentIdentity rdf:resource="http://liverpool.ac.uk/ComponentDefinition/P21685_20000_gene/constraint_1"/>
+        <sbol:restriction rdf:resource="http://sbols.org/v2#precedes"/>
+        <sbol:subject rdf:resource="http://liverpool.ac.uk/ComponentDefinition/P21685_20000_gene/P21685_20000_rbs_0/1"/>
+        <sbol:version>1</sbol:version>
+      </sbol:SequenceConstraint>
+    </sbol:sequenceConstraint>
+    <sbol:sequenceConstraint>
+      <sbol:SequenceConstraint rdf:about="http://liverpool.ac.uk/ComponentDefinition/P21685_20000_gene/constraint_2/1">
+        <sbol:displayId>constraint_2</sbol:displayId>
+        <sbol:object rdf:resource="http://liverpool.ac.uk/ComponentDefinition/P21685_20000_gene/rxn_3_3_prime_assembly_0/1"/>
+        <sbol:persistentIdentity rdf:resource="http://liverpool.ac.uk/ComponentDefinition/P21685_20000_gene/constraint_2"/>
+        <sbol:restriction rdf:resource="http://sbols.org/v2#precedes"/>
+        <sbol:subject rdf:resource="http://liverpool.ac.uk/ComponentDefinition/P21685_20000_gene/P21685_20000_cds_0/1"/>
+        <sbol:version>1</sbol:version>
+      </sbol:SequenceConstraint>
+    </sbol:sequenceConstraint>
+  </sbol:ComponentDefinition>
+  <sbol:ComponentDefinition rdf:about="http://liverpool.ac.uk/ComponentDefinition/P21685_30000_gene/1">
+    <sbol:displayId>P21685_30000_gene</sbol:displayId>
+    <sbol:persistentIdentity rdf:resource="http://liverpool.ac.uk/ComponentDefinition/P21685_30000_gene"/>
+    <sbol:role rdf:resource="http://identifiers.org/so/SO:0000704"/>
+    <sbol:type rdf:resource="http://www.biopax.org/release/biopax-level3.owl#DnaRegion"/>
+    <sbol:type rdf:resource="http://identifiers.org/so/SO:0000987"/>
+    <sbol:version>1</sbol:version>
+    <sbol:component>
+      <sbol:Component rdf:about="http://liverpool.ac.uk/ComponentDefinition/P21685_30000_gene/rxn_3_5_prime_assembly_0/1">
+        <sbol:access rdf:resource="http://sbols.org/v2#public"/>
+        <sbol:definition rdf:resource="http://liverpool.ac.uk/ComponentDefinition/rxn_3_5_prime_assembly/1"/>
+        <sbol:displayId>rxn_3_5_prime_assembly_0</sbol:displayId>
+        <sbol:persistentIdentity rdf:resource="http://liverpool.ac.uk/ComponentDefinition/P21685_30000_gene/rxn_3_5_prime_assembly_0"/>
+        <sbol:roleIntegration rdf:resource="http://sbols.org/v2#mergeRoles"/>
+        <sbol:version>1</sbol:version>
+      </sbol:Component>
+    </sbol:component>
+    <sbol:component>
+      <sbol:Component rdf:about="http://liverpool.ac.uk/ComponentDefinition/P21685_30000_gene/P21685_30000_rbs_0/1">
+        <sbol:access rdf:resource="http://sbols.org/v2#public"/>
+        <sbol:definition rdf:resource="http://liverpool.ac.uk/ComponentDefinition/P21685_30000_rbs/1"/>
+        <sbol:displayId>P21685_30000_rbs_0</sbol:displayId>
+        <sbol:persistentIdentity rdf:resource="http://liverpool.ac.uk/ComponentDefinition/P21685_30000_gene/P21685_30000_rbs_0"/>
+        <sbol:roleIntegration rdf:resource="http://sbols.org/v2#mergeRoles"/>
+        <sbol:version>1</sbol:version>
+      </sbol:Component>
+    </sbol:component>
+    <sbol:component>
+      <sbol:Component rdf:about="http://liverpool.ac.uk/ComponentDefinition/P21685_30000_gene/P21685_30000_cds_0/1">
+        <sbol:access rdf:resource="http://sbols.org/v2#public"/>
+        <sbol:definition rdf:resource="http://liverpool.ac.uk/ComponentDefinition/P21685_30000_cds/1"/>
+        <sbol:displayId>P21685_30000_cds_0</sbol:displayId>
+        <sbol:persistentIdentity rdf:resource="http://liverpool.ac.uk/ComponentDefinition/P21685_30000_gene/P21685_30000_cds_0"/>
+        <sbol:roleIntegration rdf:resource="http://sbols.org/v2#mergeRoles"/>
+        <sbol:version>1</sbol:version>
+      </sbol:Component>
+    </sbol:component>
+    <sbol:component>
+      <sbol:Component rdf:about="http://liverpool.ac.uk/ComponentDefinition/P21685_30000_gene/rxn_3_3_prime_assembly_0/1">
+        <sbol:access rdf:resource="http://sbols.org/v2#public"/>
+        <sbol:definition rdf:resource="http://liverpool.ac.uk/ComponentDefinition/rxn_3_3_prime_assembly/1"/>
+        <sbol:displayId>rxn_3_3_prime_assembly_0</sbol:displayId>
+        <sbol:persistentIdentity rdf:resource="http://liverpool.ac.uk/ComponentDefinition/P21685_30000_gene/rxn_3_3_prime_assembly_0"/>
+        <sbol:roleIntegration rdf:resource="http://sbols.org/v2#mergeRoles"/>
+        <sbol:version>1</sbol:version>
+      </sbol:Component>
+    </sbol:component>
+    <sbol:sequenceConstraint>
+      <sbol:SequenceConstraint rdf:about="http://liverpool.ac.uk/ComponentDefinition/P21685_30000_gene/constraint_0/1">
+        <sbol:displayId>constraint_0</sbol:displayId>
+        <sbol:object rdf:resource="http://liverpool.ac.uk/ComponentDefinition/P21685_30000_gene/P21685_30000_rbs_0/1"/>
+        <sbol:persistentIdentity rdf:resource="http://liverpool.ac.uk/ComponentDefinition/P21685_30000_gene/constraint_0"/>
+        <sbol:restriction rdf:resource="http://sbols.org/v2#precedes"/>
+        <sbol:subject rdf:resource="http://liverpool.ac.uk/ComponentDefinition/P21685_30000_gene/rxn_3_5_prime_assembly_0/1"/>
+        <sbol:version>1</sbol:version>
+      </sbol:SequenceConstraint>
+    </sbol:sequenceConstraint>
+    <sbol:sequenceConstraint>
+      <sbol:SequenceConstraint rdf:about="http://liverpool.ac.uk/ComponentDefinition/P21685_30000_gene/constraint_1/1">
+        <sbol:displayId>constraint_1</sbol:displayId>
+        <sbol:object rdf:resource="http://liverpool.ac.uk/ComponentDefinition/P21685_30000_gene/P21685_30000_cds_0/1"/>
+        <sbol:persistentIdentity rdf:resource="http://liverpool.ac.uk/ComponentDefinition/P21685_30000_gene/constraint_1"/>
+        <sbol:restriction rdf:resource="http://sbols.org/v2#precedes"/>
+        <sbol:subject rdf:resource="http://liverpool.ac.uk/ComponentDefinition/P21685_30000_gene/P21685_30000_rbs_0/1"/>
+        <sbol:version>1</sbol:version>
+      </sbol:SequenceConstraint>
+    </sbol:sequenceConstraint>
+    <sbol:sequenceConstraint>
+      <sbol:SequenceConstraint rdf:about="http://liverpool.ac.uk/ComponentDefinition/P21685_30000_gene/constraint_2/1">
+        <sbol:displayId>constraint_2</sbol:displayId>
+        <sbol:object rdf:resource="http://liverpool.ac.uk/ComponentDefinition/P21685_30000_gene/rxn_3_3_prime_assembly_0/1"/>
+        <sbol:persistentIdentity rdf:resource="http://liverpool.ac.uk/ComponentDefinition/P21685_30000_gene/constraint_2"/>
+        <sbol:restriction rdf:resource="http://sbols.org/v2#precedes"/>
+        <sbol:subject rdf:resource="http://liverpool.ac.uk/ComponentDefinition/P21685_30000_gene/P21685_30000_cds_0/1"/>
+        <sbol:version>1</sbol:version>
+      </sbol:SequenceConstraint>
+    </sbol:sequenceConstraint>
+  </sbol:ComponentDefinition>
+  <sbol:ComponentDefinition rdf:about="http://liverpool.ac.uk/ComponentDefinition/rxn_2_3_prime_assembly/1">
+    <sbol:displayId>rxn_2_3_prime_assembly</sbol:displayId>
+    <sbol:persistentIdentity rdf:resource="http://liverpool.ac.uk/ComponentDefinition/rxn_2_3_prime_assembly"/>
+    <sbol:role rdf:resource="http://identifiers.org/so/SO:0000143"/>
+    <sbol:type rdf:resource="http://www.biopax.org/release/biopax-level3.owl#DnaRegion"/>
+    <sbol:version>1</sbol:version>
+  </sbol:ComponentDefinition>
+  <sbol:ComponentDefinition rdf:about="http://liverpool.ac.uk/ComponentDefinition/P21685_10000_gene/1">
+    <sbol:displayId>P21685_10000_gene</sbol:displayId>
+    <sbol:persistentIdentity rdf:resource="http://liverpool.ac.uk/ComponentDefinition/P21685_10000_gene"/>
+    <sbol:role rdf:resource="http://identifiers.org/so/SO:0000704"/>
+    <sbol:type rdf:resource="http://www.biopax.org/release/biopax-level3.owl#DnaRegion"/>
+    <sbol:type rdf:resource="http://identifiers.org/so/SO:0000987"/>
+    <sbol:version>1</sbol:version>
+    <sbol:component>
+      <sbol:Component rdf:about="http://liverpool.ac.uk/ComponentDefinition/P21685_10000_gene/rxn_3_5_prime_assembly_0/1">
+        <sbol:access rdf:resource="http://sbols.org/v2#public"/>
+        <sbol:definition rdf:resource="http://liverpool.ac.uk/ComponentDefinition/rxn_3_5_prime_assembly/1"/>
+        <sbol:displayId>rxn_3_5_prime_assembly_0</sbol:displayId>
+        <sbol:persistentIdentity rdf:resource="http://liverpool.ac.uk/ComponentDefinition/P21685_10000_gene/rxn_3_5_prime_assembly_0"/>
+        <sbol:roleIntegration rdf:resource="http://sbols.org/v2#mergeRoles"/>
+        <sbol:version>1</sbol:version>
+      </sbol:Component>
+    </sbol:component>
+    <sbol:component>
+      <sbol:Component rdf:about="http://liverpool.ac.uk/ComponentDefinition/P21685_10000_gene/P21685_10000_rbs_0/1">
+        <sbol:access rdf:resource="http://sbols.org/v2#public"/>
+        <sbol:definition rdf:resource="http://liverpool.ac.uk/ComponentDefinition/P21685_10000_rbs/1"/>
+        <sbol:displayId>P21685_10000_rbs_0</sbol:displayId>
+        <sbol:persistentIdentity rdf:resource="http://liverpool.ac.uk/ComponentDefinition/P21685_10000_gene/P21685_10000_rbs_0"/>
+        <sbol:roleIntegration rdf:resource="http://sbols.org/v2#mergeRoles"/>
+        <sbol:version>1</sbol:version>
+      </sbol:Component>
+    </sbol:component>
+    <sbol:component>
+      <sbol:Component rdf:about="http://liverpool.ac.uk/ComponentDefinition/P21685_10000_gene/P21685_10000_cds_0/1">
+        <sbol:access rdf:resource="http://sbols.org/v2#public"/>
+        <sbol:definition rdf:resource="http://liverpool.ac.uk/ComponentDefinition/P21685_10000_cds/1"/>
+        <sbol:displayId>P21685_10000_cds_0</sbol:displayId>
+        <sbol:persistentIdentity rdf:resource="http://liverpool.ac.uk/ComponentDefinition/P21685_10000_gene/P21685_10000_cds_0"/>
+        <sbol:roleIntegration rdf:resource="http://sbols.org/v2#mergeRoles"/>
+        <sbol:version>1</sbol:version>
+      </sbol:Component>
+    </sbol:component>
+    <sbol:component>
+      <sbol:Component rdf:about="http://liverpool.ac.uk/ComponentDefinition/P21685_10000_gene/rxn_3_3_prime_assembly_0/1">
+        <sbol:access rdf:resource="http://sbols.org/v2#public"/>
+        <sbol:definition rdf:resource="http://liverpool.ac.uk/ComponentDefinition/rxn_3_3_prime_assembly/1"/>
+        <sbol:displayId>rxn_3_3_prime_assembly_0</sbol:displayId>
+        <sbol:persistentIdentity rdf:resource="http://liverpool.ac.uk/ComponentDefinition/P21685_10000_gene/rxn_3_3_prime_assembly_0"/>
+        <sbol:roleIntegration rdf:resource="http://sbols.org/v2#mergeRoles"/>
+        <sbol:version>1</sbol:version>
+      </sbol:Component>
+    </sbol:component>
+    <sbol:sequenceConstraint>
+      <sbol:SequenceConstraint rdf:about="http://liverpool.ac.uk/ComponentDefinition/P21685_10000_gene/constraint_0/1">
+        <sbol:displayId>constraint_0</sbol:displayId>
+        <sbol:object rdf:resource="http://liverpool.ac.uk/ComponentDefinition/P21685_10000_gene/P21685_10000_rbs_0/1"/>
+        <sbol:persistentIdentity rdf:resource="http://liverpool.ac.uk/ComponentDefinition/P21685_10000_gene/constraint_0"/>
+        <sbol:restriction rdf:resource="http://sbols.org/v2#precedes"/>
+        <sbol:subject rdf:resource="http://liverpool.ac.uk/ComponentDefinition/P21685_10000_gene/rxn_3_5_prime_assembly_0/1"/>
+        <sbol:version>1</sbol:version>
+      </sbol:SequenceConstraint>
+    </sbol:sequenceConstraint>
+    <sbol:sequenceConstraint>
+      <sbol:SequenceConstraint rdf:about="http://liverpool.ac.uk/ComponentDefinition/P21685_10000_gene/constraint_1/1">
+        <sbol:displayId>constraint_1</sbol:displayId>
+        <sbol:object rdf:resource="http://liverpool.ac.uk/ComponentDefinition/P21685_10000_gene/P21685_10000_cds_0/1"/>
+        <sbol:persistentIdentity rdf:resource="http://liverpool.ac.uk/ComponentDefinition/P21685_10000_gene/constraint_1"/>
+        <sbol:restriction rdf:resource="http://sbols.org/v2#precedes"/>
+        <sbol:subject rdf:resource="http://liverpool.ac.uk/ComponentDefinition/P21685_10000_gene/P21685_10000_rbs_0/1"/>
+        <sbol:version>1</sbol:version>
+      </sbol:SequenceConstraint>
+    </sbol:sequenceConstraint>
+    <sbol:sequenceConstraint>
+      <sbol:SequenceConstraint rdf:about="http://liverpool.ac.uk/ComponentDefinition/P21685_10000_gene/constraint_2/1">
+        <sbol:displayId>constraint_2</sbol:displayId>
+        <sbol:object rdf:resource="http://liverpool.ac.uk/ComponentDefinition/P21685_10000_gene/rxn_3_3_prime_assembly_0/1"/>
+        <sbol:persistentIdentity rdf:resource="http://liverpool.ac.uk/ComponentDefinition/P21685_10000_gene/constraint_2"/>
+        <sbol:restriction rdf:resource="http://sbols.org/v2#precedes"/>
+        <sbol:subject rdf:resource="http://liverpool.ac.uk/ComponentDefinition/P21685_10000_gene/P21685_10000_cds_0/1"/>
+        <sbol:version>1</sbol:version>
+      </sbol:SequenceConstraint>
+    </sbol:sequenceConstraint>
+  </sbol:ComponentDefinition>
+  <sbol:ComponentDefinition rdf:about="http://liverpool.ac.uk/ComponentDefinition/P21687_10000_rbs/1">
+    <sbol:displayId>P21687_10000_rbs</sbol:displayId>
+    <sbol:persistentIdentity rdf:resource="http://liverpool.ac.uk/ComponentDefinition/P21687_10000_rbs"/>
+    <sbol:role rdf:resource="http://identifiers.org/so/SO:0000139"/>
+    <sbol:type rdf:resource="http://www.biopax.org/release/biopax-level3.owl#DnaRegion"/>
+    <sbol:version>1</sbol:version>
+  </sbol:ComponentDefinition>
+  <sbol:ComponentDefinition rdf:about="http://liverpool.ac.uk/ComponentDefinition/P21687_10000_cds/1">
+    <sbol:displayId>P21687_10000_cds</sbol:displayId>
+    <sbol:persistentIdentity rdf:resource="http://liverpool.ac.uk/ComponentDefinition/P21687_10000_cds"/>
+    <sbol:role rdf:resource="http://identifiers.org/so/SO:0000316"/>
+    <sbol:type rdf:resource="http://www.biopax.org/release/biopax-level3.owl#DnaRegion"/>
+    <sbol:version>1</sbol:version>
+  </sbol:ComponentDefinition>
+  <sbol:ComponentDefinition rdf:about="http://liverpool.ac.uk/ComponentDefinition/P21687_10000_gene/1">
+    <sbol:displayId>P21687_10000_gene</sbol:displayId>
+    <sbol:persistentIdentity rdf:resource="http://liverpool.ac.uk/ComponentDefinition/P21687_10000_gene"/>
+    <sbol:role rdf:resource="http://identifiers.org/so/SO:0000704"/>
+    <sbol:type rdf:resource="http://www.biopax.org/release/biopax-level3.owl#DnaRegion"/>
+    <sbol:type rdf:resource="http://identifiers.org/so/SO:0000987"/>
+    <sbol:version>1</sbol:version>
+    <sbol:component>
+      <sbol:Component rdf:about="http://liverpool.ac.uk/ComponentDefinition/P21687_10000_gene/rxn_3_5_prime_assembly_0/1">
+        <sbol:access rdf:resource="http://sbols.org/v2#public"/>
+        <sbol:definition rdf:resource="http://liverpool.ac.uk/ComponentDefinition/rxn_3_5_prime_assembly/1"/>
+        <sbol:displayId>rxn_3_5_prime_assembly_0</sbol:displayId>
+        <sbol:persistentIdentity rdf:resource="http://liverpool.ac.uk/ComponentDefinition/P21687_10000_gene/rxn_3_5_prime_assembly_0"/>
+        <sbol:roleIntegration rdf:resource="http://sbols.org/v2#mergeRoles"/>
+        <sbol:version>1</sbol:version>
+      </sbol:Component>
+    </sbol:component>
+    <sbol:component>
+      <sbol:Component rdf:about="http://liverpool.ac.uk/ComponentDefinition/P21687_10000_gene/P21687_10000_rbs_0/1">
+        <sbol:access rdf:resource="http://sbols.org/v2#public"/>
+        <sbol:definition rdf:resource="http://liverpool.ac.uk/ComponentDefinition/P21687_10000_rbs/1"/>
+        <sbol:displayId>P21687_10000_rbs_0</sbol:displayId>
+        <sbol:persistentIdentity rdf:resource="http://liverpool.ac.uk/ComponentDefinition/P21687_10000_gene/P21687_10000_rbs_0"/>
+        <sbol:roleIntegration rdf:resource="http://sbols.org/v2#mergeRoles"/>
+        <sbol:version>1</sbol:version>
+      </sbol:Component>
+    </sbol:component>
+    <sbol:component>
+      <sbol:Component rdf:about="http://liverpool.ac.uk/ComponentDefinition/P21687_10000_gene/P21687_10000_cds_0/1">
+        <sbol:access rdf:resource="http://sbols.org/v2#public"/>
+        <sbol:definition rdf:resource="http://liverpool.ac.uk/ComponentDefinition/P21687_10000_cds/1"/>
+        <sbol:displayId>P21687_10000_cds_0</sbol:displayId>
+        <sbol:persistentIdentity rdf:resource="http://liverpool.ac.uk/ComponentDefinition/P21687_10000_gene/P21687_10000_cds_0"/>
+        <sbol:roleIntegration rdf:resource="http://sbols.org/v2#mergeRoles"/>
+        <sbol:version>1</sbol:version>
+      </sbol:Component>
+    </sbol:component>
+    <sbol:component>
+      <sbol:Component rdf:about="http://liverpool.ac.uk/ComponentDefinition/P21687_10000_gene/rxn_3_3_prime_assembly_0/1">
+        <sbol:access rdf:resource="http://sbols.org/v2#public"/>
+        <sbol:definition rdf:resource="http://liverpool.ac.uk/ComponentDefinition/rxn_3_3_prime_assembly/1"/>
+        <sbol:displayId>rxn_3_3_prime_assembly_0</sbol:displayId>
+        <sbol:persistentIdentity rdf:resource="http://liverpool.ac.uk/ComponentDefinition/P21687_10000_gene/rxn_3_3_prime_assembly_0"/>
+        <sbol:roleIntegration rdf:resource="http://sbols.org/v2#mergeRoles"/>
+        <sbol:version>1</sbol:version>
+      </sbol:Component>
+    </sbol:component>
+    <sbol:sequenceConstraint>
+      <sbol:SequenceConstraint rdf:about="http://liverpool.ac.uk/ComponentDefinition/P21687_10000_gene/constraint_0/1">
+        <sbol:displayId>constraint_0</sbol:displayId>
+        <sbol:object rdf:resource="http://liverpool.ac.uk/ComponentDefinition/P21687_10000_gene/P21687_10000_rbs_0/1"/>
+        <sbol:persistentIdentity rdf:resource="http://liverpool.ac.uk/ComponentDefinition/P21687_10000_gene/constraint_0"/>
+        <sbol:restriction rdf:resource="http://sbols.org/v2#precedes"/>
+        <sbol:subject rdf:resource="http://liverpool.ac.uk/ComponentDefinition/P21687_10000_gene/rxn_3_5_prime_assembly_0/1"/>
+        <sbol:version>1</sbol:version>
+      </sbol:SequenceConstraint>
+    </sbol:sequenceConstraint>
+    <sbol:sequenceConstraint>
+      <sbol:SequenceConstraint rdf:about="http://liverpool.ac.uk/ComponentDefinition/P21687_10000_gene/constraint_1/1">
+        <sbol:displayId>constraint_1</sbol:displayId>
+        <sbol:object rdf:resource="http://liverpool.ac.uk/ComponentDefinition/P21687_10000_gene/P21687_10000_cds_0/1"/>
+        <sbol:persistentIdentity rdf:resource="http://liverpool.ac.uk/ComponentDefinition/P21687_10000_gene/constraint_1"/>
+        <sbol:restriction rdf:resource="http://sbols.org/v2#precedes"/>
+        <sbol:subject rdf:resource="http://liverpool.ac.uk/ComponentDefinition/P21687_10000_gene/P21687_10000_rbs_0/1"/>
+        <sbol:version>1</sbol:version>
+      </sbol:SequenceConstraint>
+    </sbol:sequenceConstraint>
+    <sbol:sequenceConstraint>
+      <sbol:SequenceConstraint rdf:about="http://liverpool.ac.uk/ComponentDefinition/P21687_10000_gene/constraint_2/1">
+        <sbol:displayId>constraint_2</sbol:displayId>
+        <sbol:object rdf:resource="http://liverpool.ac.uk/ComponentDefinition/P21687_10000_gene/rxn_3_3_prime_assembly_0/1"/>
+        <sbol:persistentIdentity rdf:resource="http://liverpool.ac.uk/ComponentDefinition/P21687_10000_gene/constraint_2"/>
+        <sbol:restriction rdf:resource="http://sbols.org/v2#precedes"/>
+        <sbol:subject rdf:resource="http://liverpool.ac.uk/ComponentDefinition/P21687_10000_gene/P21687_10000_cds_0/1"/>
+        <sbol:version>1</sbol:version>
+      </sbol:SequenceConstraint>
+    </sbol:sequenceConstraint>
+  </sbol:ComponentDefinition>
+  <sbol:ComponentDefinition rdf:about="http://liverpool.ac.uk/ComponentDefinition/P21684_20000_cds/1">
+    <sbol:displayId>P21684_20000_cds</sbol:displayId>
+    <sbol:persistentIdentity rdf:resource="http://liverpool.ac.uk/ComponentDefinition/P21684_20000_cds"/>
+    <sbol:role rdf:resource="http://identifiers.org/so/SO:0000316"/>
+    <sbol:type rdf:resource="http://www.biopax.org/release/biopax-level3.owl#DnaRegion"/>
+    <sbol:version>1</sbol:version>
+  </sbol:ComponentDefinition>
+  <sbol:ComponentDefinition rdf:about="http://liverpool.ac.uk/ComponentDefinition/P21687_30000_rbs/1">
+    <sbol:displayId>P21687_30000_rbs</sbol:displayId>
+    <sbol:persistentIdentity rdf:resource="http://liverpool.ac.uk/ComponentDefinition/P21687_30000_rbs"/>
+    <sbol:role rdf:resource="http://identifiers.org/so/SO:0000139"/>
+    <sbol:type rdf:resource="http://www.biopax.org/release/biopax-level3.owl#DnaRegion"/>
+    <sbol:version>1</sbol:version>
+  </sbol:ComponentDefinition>
+  <sbol:ComponentDefinition rdf:about="http://liverpool.ac.uk/ComponentDefinition/P21688_10000_cds/1">
+    <sbol:displayId>P21688_10000_cds</sbol:displayId>
+    <sbol:persistentIdentity rdf:resource="http://liverpool.ac.uk/ComponentDefinition/P21688_10000_cds"/>
+    <sbol:role rdf:resource="http://identifiers.org/so/SO:0000316"/>
+    <sbol:type rdf:resource="http://www.biopax.org/release/biopax-level3.owl#DnaRegion"/>
+    <sbol:version>1</sbol:version>
+  </sbol:ComponentDefinition>
+  <sbol:ComponentDefinition rdf:about="http://liverpool.ac.uk/ComponentDefinition/P21688_10000_rbs/1">
+    <sbol:displayId>P21688_10000_rbs</sbol:displayId>
+    <sbol:persistentIdentity rdf:resource="http://liverpool.ac.uk/ComponentDefinition/P21688_10000_rbs"/>
+    <sbol:role rdf:resource="http://identifiers.org/so/SO:0000139"/>
+    <sbol:type rdf:resource="http://www.biopax.org/release/biopax-level3.owl#DnaRegion"/>
+    <sbol:version>1</sbol:version>
+  </sbol:ComponentDefinition>
+  <sbol:ComponentDefinition rdf:about="http://liverpool.ac.uk/ComponentDefinition/P21684_30000_cds/1">
+    <sbol:displayId>P21684_30000_cds</sbol:displayId>
+    <sbol:persistentIdentity rdf:resource="http://liverpool.ac.uk/ComponentDefinition/P21684_30000_cds"/>
+    <sbol:role rdf:resource="http://identifiers.org/so/SO:0000316"/>
+    <sbol:type rdf:resource="http://www.biopax.org/release/biopax-level3.owl#DnaRegion"/>
+    <sbol:version>1</sbol:version>
+  </sbol:ComponentDefinition>
+  <sbol:ComponentDefinition rdf:about="http://liverpool.ac.uk/ComponentDefinition/P21688_10000_gene/1">
+    <sbol:displayId>P21688_10000_gene</sbol:displayId>
+    <sbol:persistentIdentity rdf:resource="http://liverpool.ac.uk/ComponentDefinition/P21688_10000_gene"/>
+    <sbol:role rdf:resource="http://identifiers.org/so/SO:0000704"/>
+    <sbol:type rdf:resource="http://www.biopax.org/release/biopax-level3.owl#DnaRegion"/>
+    <sbol:type rdf:resource="http://identifiers.org/so/SO:0000987"/>
+    <sbol:version>1</sbol:version>
+    <sbol:component>
+      <sbol:Component rdf:about="http://liverpool.ac.uk/ComponentDefinition/P21688_10000_gene/rxn_3_5_prime_assembly_0/1">
+        <sbol:access rdf:resource="http://sbols.org/v2#public"/>
+        <sbol:definition rdf:resource="http://liverpool.ac.uk/ComponentDefinition/rxn_3_5_prime_assembly/1"/>
+        <sbol:displayId>rxn_3_5_prime_assembly_0</sbol:displayId>
+        <sbol:persistentIdentity rdf:resource="http://liverpool.ac.uk/ComponentDefinition/P21688_10000_gene/rxn_3_5_prime_assembly_0"/>
+        <sbol:roleIntegration rdf:resource="http://sbols.org/v2#mergeRoles"/>
+        <sbol:version>1</sbol:version>
+      </sbol:Component>
+    </sbol:component>
+    <sbol:component>
+      <sbol:Component rdf:about="http://liverpool.ac.uk/ComponentDefinition/P21688_10000_gene/P21688_10000_rbs_0/1">
+        <sbol:access rdf:resource="http://sbols.org/v2#public"/>
+        <sbol:definition rdf:resource="http://liverpool.ac.uk/ComponentDefinition/P21688_10000_rbs/1"/>
+        <sbol:displayId>P21688_10000_rbs_0</sbol:displayId>
+        <sbol:persistentIdentity rdf:resource="http://liverpool.ac.uk/ComponentDefinition/P21688_10000_gene/P21688_10000_rbs_0"/>
+        <sbol:roleIntegration rdf:resource="http://sbols.org/v2#mergeRoles"/>
+        <sbol:version>1</sbol:version>
+      </sbol:Component>
+    </sbol:component>
+    <sbol:component>
+      <sbol:Component rdf:about="http://liverpool.ac.uk/ComponentDefinition/P21688_10000_gene/P21688_10000_cds_0/1">
+        <sbol:access rdf:resource="http://sbols.org/v2#public"/>
+        <sbol:definition rdf:resource="http://liverpool.ac.uk/ComponentDefinition/P21688_10000_cds/1"/>
+        <sbol:displayId>P21688_10000_cds_0</sbol:displayId>
+        <sbol:persistentIdentity rdf:resource="http://liverpool.ac.uk/ComponentDefinition/P21688_10000_gene/P21688_10000_cds_0"/>
+        <sbol:roleIntegration rdf:resource="http://sbols.org/v2#mergeRoles"/>
+        <sbol:version>1</sbol:version>
+      </sbol:Component>
+    </sbol:component>
+    <sbol:component>
+      <sbol:Component rdf:about="http://liverpool.ac.uk/ComponentDefinition/P21688_10000_gene/rxn_3_3_prime_assembly_0/1">
+        <sbol:access rdf:resource="http://sbols.org/v2#public"/>
+        <sbol:definition rdf:resource="http://liverpool.ac.uk/ComponentDefinition/rxn_3_3_prime_assembly/1"/>
+        <sbol:displayId>rxn_3_3_prime_assembly_0</sbol:displayId>
+        <sbol:persistentIdentity rdf:resource="http://liverpool.ac.uk/ComponentDefinition/P21688_10000_gene/rxn_3_3_prime_assembly_0"/>
+        <sbol:roleIntegration rdf:resource="http://sbols.org/v2#mergeRoles"/>
+        <sbol:version>1</sbol:version>
+      </sbol:Component>
+    </sbol:component>
+    <sbol:sequenceConstraint>
+      <sbol:SequenceConstraint rdf:about="http://liverpool.ac.uk/ComponentDefinition/P21688_10000_gene/constraint_0/1">
+        <sbol:displayId>constraint_0</sbol:displayId>
+        <sbol:object rdf:resource="http://liverpool.ac.uk/ComponentDefinition/P21688_10000_gene/P21688_10000_rbs_0/1"/>
+        <sbol:persistentIdentity rdf:resource="http://liverpool.ac.uk/ComponentDefinition/P21688_10000_gene/constraint_0"/>
+        <sbol:restriction rdf:resource="http://sbols.org/v2#precedes"/>
+        <sbol:subject rdf:resource="http://liverpool.ac.uk/ComponentDefinition/P21688_10000_gene/rxn_3_5_prime_assembly_0/1"/>
+        <sbol:version>1</sbol:version>
+      </sbol:SequenceConstraint>
+    </sbol:sequenceConstraint>
+    <sbol:sequenceConstraint>
+      <sbol:SequenceConstraint rdf:about="http://liverpool.ac.uk/ComponentDefinition/P21688_10000_gene/constraint_1/1">
+        <sbol:displayId>constraint_1</sbol:displayId>
+        <sbol:object rdf:resource="http://liverpool.ac.uk/ComponentDefinition/P21688_10000_gene/P21688_10000_cds_0/1"/>
+        <sbol:persistentIdentity rdf:resource="http://liverpool.ac.uk/ComponentDefinition/P21688_10000_gene/constraint_1"/>
+        <sbol:restriction rdf:resource="http://sbols.org/v2#precedes"/>
+        <sbol:subject rdf:resource="http://liverpool.ac.uk/ComponentDefinition/P21688_10000_gene/P21688_10000_rbs_0/1"/>
+        <sbol:version>1</sbol:version>
+      </sbol:SequenceConstraint>
+    </sbol:sequenceConstraint>
+    <sbol:sequenceConstraint>
+      <sbol:SequenceConstraint rdf:about="http://liverpool.ac.uk/ComponentDefinition/P21688_10000_gene/constraint_2/1">
+        <sbol:displayId>constraint_2</sbol:displayId>
+        <sbol:object rdf:resource="http://liverpool.ac.uk/ComponentDefinition/P21688_10000_gene/rxn_3_3_prime_assembly_0/1"/>
+        <sbol:persistentIdentity rdf:resource="http://liverpool.ac.uk/ComponentDefinition/P21688_10000_gene/constraint_2"/>
+        <sbol:restriction rdf:resource="http://sbols.org/v2#precedes"/>
+        <sbol:subject rdf:resource="http://liverpool.ac.uk/ComponentDefinition/P21688_10000_gene/P21688_10000_cds_0/1"/>
+        <sbol:version>1</sbol:version>
+      </sbol:SequenceConstraint>
+    </sbol:sequenceConstraint>
+  </sbol:ComponentDefinition>
+</rdf:RDF>

--- a/sbml2sbol/wrap.xml
+++ b/sbml2sbol/wrap.xml
@@ -23,12 +23,12 @@
         <param name="sbml_single_input" type="data" format="sbml" label="Pathway (SBML)" />
         <section name="adv" title="Advanced Options" expanded="false">
             <param argument="--rbs" type="boolean" truevalue="--rbs True" falsevalue="--rbs False" label="Calculate the RBS strength?" checked="true" help="Calculate or not the RBS (Ribosome Binding Site) strength (default: True)"/>
-            <param name="max_prot_per_react" type="integer" value="3" min="1" max="20" label="The maximum number of proteins per reaction" />
-            <param name="tirs" type="text" optional="true" label="Space separated RBS strength values" />
-            <param name="pathway_id" type="text" value="rp_pathway" label="Group ID of the heterologous pathway" >
+            <param argument="--max_prot_per_react" type="integer" value="3" min="1" max="20" label="The maximum number of proteins per reaction" />
+            <param argument="--tirs" type="text" optional="true" label="Space separated RBS strength values" />
+            <param argument="--pathway_id" type="text" value="rp_pathway" label="Group ID of the heterologous pathway" >
                 <validator type="empty_field" message="Pathway ID is required"/>
             </param>
-            <param name="uniprotID_key" type="text" value="selenzy" label="Uniprot ID" >
+            <param argument="--uniprotID_key" type="text" value="selenzy" label="Uniprot ID" >
                 <validator type="empty_field" message="Uniprot ID is required"/>
             </param>
         </section>

--- a/sbml2sbol/wrap.xml
+++ b/sbml2sbol/wrap.xml
@@ -42,6 +42,13 @@
             <param name="sbml_single_input" value="lycopene.xml" />
             <output name="sbol_outfile" file="sbol_lycopene_output.xml" ftype="xml" compare="diff" sort="true"/>
         </test>
+        <test>
+        <!-- test 2: check if identical outputs are produced without RBS calculation  -->
+            <param name="sbml_single_input" value="lycopene.xml" />
+            <param name="rbs" value="--rbs False" />
+            <param name="max_prot_per_react" value="5" />
+            <output name="sbol_outfile" file="sbol_lycopene_output2.xml" ftype="xml" compare="diff" sort="true"/>
+        </test>
     </tests>
     <help><![CDATA[
 SBML to SBOL


### PR DESCRIPTION
- add a second test with advanced parameters

- replace **name** by **argument**: If the parameter reflects just one command line argument of a certain tool, this tag should be set to that particular argument. It is rendered in parenthesis after the help section, and it will create the name attribute (if not given explicitly) from the argument attribute by stripping leading dashes and replacing all remaining dashes by underscores (e.g. if argument="--long-parameter" then name="long_parameter" is implicit).