### PR TITLE
doc(optdoe): optimize name and def tool

### DIFF
--- a/OptDoE/wrap.xml
+++ b/OptDoE/wrap.xml
@@ -1,5 +1,5 @@
-<tool id="optdoe" name="Design of Experiment" version="@TOOL_VERSION@+galaxy@VERSION_SUFFIX@" profile="21.09">
-    <description>An optimal design of experiments (DoE) base package for synthetic biology</description>
+<tool id="optdoe" name="Optimal Design of Experiment" version="@TOOL_VERSION@+galaxy@VERSION_SUFFIX@" profile="21.09">
+    <description>Combine selected genetic parts and enzyme variants for the desired pathways</description>
     <macros>
         <token name="@VERSION_SUFFIX@">0</token>
         <token name="@TOOL_VERSION@">2.0.2</token>


### PR DESCRIPTION
Optimize name and description tool because they are redundant (as requested by IUC: https://github.com/galaxyproject/tools-iuc/pull/4879 )