### PR TITLE
style(rpranker): add single quotes and element_identifier

### DIFF
--- a/rptools/rpranker.xml
+++ b/rptools/rpranker.xml
@@ -10,14 +10,14 @@
     </stdio>
     <command detect_errors="exit_code"><![CDATA[
         #for $file in $pathway_collection
-            ln -s $file $file.name &&
+            ln -s '$file' '$file.element_identifier' &&
         #end for
 
         python -m rptools.rprank
         --pathways
 
         #for $file in $pathway_collection
-            $file.name
+            '$file.element_identifier'
         #end for
 
         > '$sorted_pathways'


### PR DESCRIPTION
- Use "element_identifier" instead of "name".
- Single quotes all paths.