### PR TITLE
Updating rp2biosensor from version 3.1.0 to 3.2.1

### DIFF
--- a/tools/rp2biosensor/rp2biosensor.xml
+++ b/tools/rp2biosensor/rp2biosensor.xml
@@ -2,7 +2,7 @@
     <description>Build Sensing-Enabling Metabolic Pathways from RetroPath2.0 output</description>
     <macros>
         <token name="@VERSION_SUFFIX@">0</token>
-        <token name="@TOOL_VERSION@">3.1.0</token>
+        <token name="@TOOL_VERSION@">3.2.1</token>
     </macros>
     <requirements>
         <requirement type="package" version="@TOOL_VERSION@">rp2biosensor</requirement>


### PR DESCRIPTION
Hello! This is an automated update of the following tool: **rp2biosensor**. I created this PR because I think the tool's main dependency is out of date, i.e. there is a newer version available through conda.

I have updated rp2biosensor from version 3.1.0 to 3.2.1.

For any comments, queries or criticism about the bot, not related to the tool being updated in this PR, please create an issue [here](https://github.com/brsynth/synbiocad-galaxy-wrappers/issues/new).