### PR TITLE
Updating rpbasicdesign from version 1.1.0 to 1.2.2

### DIFF
--- a/tools/rpbasicdesign/rpbasicdesign.xml
+++ b/tools/rpbasicdesign/rpbasicdesign.xml
@@ -2,7 +2,7 @@
     <description>Build DNA-BOT input files from rpSBML</description>
     <macros>
         <token name="@VERSION_SUFFIX@">0</token>
-        <token name="@TOOL_VERSION@">1.1.0</token>
+        <token name="@TOOL_VERSION@">1.2.2</token>
     </macros>
     <requirements>
         <requirement type="package" version="@TOOL_VERSION@">rpbasicdesign</requirement>


### PR DESCRIPTION
Hello! This is an automated update of the following tool: **rpbasicdesign**. I created this PR because I think the tool's main dependency is out of date, i.e. there is a newer version available through conda.

I have updated rpbasicdesign from version 1.1.0 to 1.2.2.

For any comments, queries or criticism about the bot, not related to the tool being updated in this PR, please create an issue [here](https://github.com/brsynth/synbiocad-galaxy-wrappers/issues/new).