### PR TITLE
Updating sbol_converter from version 1.0a16 to 1.0a17

### DIFF
--- a/tools/sbol_converter/sbol_converter.xml
+++ b/tools/sbol_converter/sbol_converter.xml
@@ -2,7 +2,7 @@
     <description>Convert between SBOL3 and other genetic design formats</description>
     <macros>
         <token name="@VERSION_SUFFIX@">0</token>
-        <token name="@TOOL_VERSION@">1.0a16</token>
+        <token name="@TOOL_VERSION@">1.0a17</token>
     </macros>
     <requirements>
         <requirement type="package" version="@TOOL_VERSION@">sbol-utilities</requirement>


### PR DESCRIPTION
Hello! This is an automated update of the following tool: **sbol_converter**. I created this PR because I think the tool's main dependency is out of date, i.e. there is a newer version available through conda.

I have updated sbol_converter from version 1.0a16 to 1.0a17.

**Project home page:** https://github.com/SynBioDex/SBOL-utilities/releases

For any comments, queries or criticism about the bot, not related to the tool being updated in this PR, please create an issue [here](https://github.com/brsynth/synbiocad-galaxy-wrappers/issues/new).